### PR TITLE
fix - replace all instances of pidContentId

### DIFF
--- a/src/msgreader.js
+++ b/src/msgreader.js
@@ -41,7 +41,7 @@ function extractMsg(fileBuffer) {
             const base64String = `data:${attachment.attachMimeTag};base64,${contentBase64}`;
 
             if (attachment.attachMimeTag && attachment.attachMimeTag.startsWith('image/')) {
-                emailBodyContentHTML = emailBodyContentHTML.replace(`cid:${attachment.pidContentId}`, base64String);
+                emailBodyContentHTML = emailBodyContentHTML.replaceAll(`cid:${attachment.pidContentId}`, base64String);
             } else {
                 emailBodyContentHTML = emailBodyContentHTML.replace(`href="cid:${attachment.pidContentId}"`, `href="${base64String}"`);
             }


### PR DESCRIPTION
An msg file can have multiple references to the same pidContentId. Typically found in email threads with the same signature image in multiple positions within the same msg.

This PR will fix the image references, so that all images referencing the same pidContentId is rendered