### PR TITLE
fix(msg): robust charset decoding for MSG HTML using iconv-lite; map cp949

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -84,14 +84,20 @@ function extractMsg(fileBuffer) {
             } else if (msgInfo.internetCodepage === 932) {
                 charset = 'shift_jis'; // Japanese
             } else if (msgInfo.internetCodepage === 949) {
-                charset = 'euc-kr'; // Korean
+                charset = 'cp949'; // Korean
             } else if (msgInfo.internetCodepage === 928) {
                 charset = 'gb2312'; // Simplified Chinese
             }
             if (typeof TextDecoder !== 'undefined') {
-                htmlStr = new TextDecoder(charset).decode(htmlArr);
+                try {
+                    htmlStr = new TextDecoder(charset).decode(htmlArr);
+                } catch (e) {
+                    // Fallback for charsets not supported by TextDecoder
+                    htmlStr = iconvLite.decode(Buffer.from(htmlArr), charset);
+                }
             } else {
-                htmlStr = Buffer.from(htmlArr).toString(charset);
+                // Node fallback: support broader set of encodings via iconv-lite
+                htmlStr = iconvLite.decode(Buffer.from(htmlArr), charset);
             }
             emailBodyContentHTML = htmlStr;
         } catch (err) {


### PR DESCRIPTION
This fixes a Node fallback decoding regression for non-UTF-8 charsets by using iconv-lite when TextDecoder is unavailable or fails.

- Use iconv-lite decode in fallback path
- Try TextDecoder, then fallback to iconv-lite on error
- Map InternetCodepage 949 to cp949

Closes #10.

Reference: https://github.com/Rasalas/msg-reader/issues/10