### PR TITLE
Add zoom controls to inline image previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,9 @@
                             </svg>
                         </button>
                     </div>
+                    <a id="attachmentModalSourceLink" href="#" class="attachment-modal-source-link" title="Open linked target" target="_blank" rel="noopener noreferrer" hidden>
+                        Open link
+                    </a>
                     <a id="attachmentModalDownload" href="#" download="" class="attachment-modal-download" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -194,6 +197,27 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
                                 </svg>
                                 <span>Always dark</span>
+                                <svg class="check-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                                </svg>
+                            </button>
+                        </div>
+                        <div class="theme-menu-section">
+                            <div class="theme-menu-label">Inline Images</div>
+                            <button class="theme-menu-item" data-type="inline-images" data-inline-images="collapsed">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 7.5h16.5m-16.5 4.5h9m-9 4.5h7.5" />
+                                </svg>
+                                <span>Collapsed by default</span>
+                                <svg class="check-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                                </svg>
+                            </button>
+                            <button class="theme-menu-item" data-type="inline-images" data-inline-images="expanded">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.159 2.159M3.75 19.5h16.5A1.5 1.5 0 0 0 21.75 18V6A1.5 1.5 0 0 0 20.25 4.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm11.25-10.5h.008v.008H15V9Z" />
+                                </svg>
+                                <span>Expanded by default</span>
                                 <svg class="check-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
                                 </svg>

--- a/index.html
+++ b/index.html
@@ -51,6 +51,21 @@
                 </button>
                 <span id="attachmentModalFilename" class="attachment-modal-filename" role="heading" aria-level="2"></span>
                 <div class="attachment-modal-actions">
+                    <div id="attachmentModalZoomControls" class="attachment-modal-zoom-controls" hidden>
+                        <button id="attachmentModalZoomOut" type="button" class="attachment-modal-zoom-button" title="Zoom out" aria-label="Zoom out">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor" class="w-4 h-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14" />
+                            </svg>
+                        </button>
+                        <button id="attachmentModalZoomReset" type="button" class="attachment-modal-zoom-button attachment-modal-zoom-reset" title="Reset zoom" aria-label="Reset zoom">
+                            <span id="attachmentModalZoomValue" class="attachment-modal-zoom-value">100%</span>
+                        </button>
+                        <button id="attachmentModalZoomIn" type="button" class="attachment-modal-zoom-button" title="Zoom in" aria-label="Zoom in">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor" class="w-4 h-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m-7-7h14" />
+                            </svg>
+                        </button>
+                    </div>
                     <a id="attachmentModalDownload" href="#" download="" class="attachment-modal-download" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />

--- a/src/js/InlineImagePreference.js
+++ b/src/js/InlineImagePreference.js
@@ -1,0 +1,32 @@
+import { storage } from './storage.js';
+
+export const INLINE_IMAGE_ATTACHMENT_VISIBILITY = {
+    COLLAPSED: 'collapsed',
+    EXPANDED: 'expanded'
+};
+
+export const INLINE_IMAGE_ATTACHMENT_STORAGE_KEY = 'msgReader_inlineImageAttachments';
+
+export function getInlineImageAttachmentVisibility() {
+    const savedValue = storage.get(
+        INLINE_IMAGE_ATTACHMENT_STORAGE_KEY,
+        INLINE_IMAGE_ATTACHMENT_VISIBILITY.COLLAPSED
+    );
+
+    return Object.values(INLINE_IMAGE_ATTACHMENT_VISIBILITY).includes(savedValue)
+        ? savedValue
+        : INLINE_IMAGE_ATTACHMENT_VISIBILITY.COLLAPSED;
+}
+
+export function setInlineImageAttachmentVisibility(visibility) {
+    if (!Object.values(INLINE_IMAGE_ATTACHMENT_VISIBILITY).includes(visibility)) {
+        return false;
+    }
+
+    return storage.set(INLINE_IMAGE_ATTACHMENT_STORAGE_KEY, visibility);
+}
+
+export function inlineImageAttachmentsExpandedByDefault() {
+    return getInlineImageAttachmentVisibility() === INLINE_IMAGE_ATTACHMENT_VISIBILITY.EXPANDED;
+}
+

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -6,6 +6,10 @@ import KeyboardManager from './KeyboardManager.js';
 import { extractMsg, extractEml } from './utils.js';
 import { isTauri, getPendingFiles, onFileOpen, onFileDrop, checkForUpdates } from './tauri-bridge.js';
 import { themeManager, THEMES, EMAIL_THEMES } from './ThemeManager.js';
+import {
+    getInlineImageAttachmentVisibility,
+    setInlineImageAttachmentVisibility
+} from './InlineImagePreference.js';
 import { devModeManager } from './DevModeManager.js';
 import { DevPanel } from './ui/DevPanel.js';
 
@@ -243,6 +247,11 @@ function initTheme() {
                 themeManager.setTheme(theme);
             } else if (type === 'email') {
                 themeManager.setEmailTheme(theme);
+            } else if (type === 'inline-images') {
+                setInlineImageAttachmentVisibility(item.dataset.inlineImages);
+                document.dispatchEvent(new CustomEvent('inline-image-attachment-visibility-change', {
+                    detail: { visibility: item.dataset.inlineImages }
+                }));
             }
 
             updateThemeUI();
@@ -252,6 +261,10 @@ function initTheme() {
 
     // Listen for theme changes
     themeManager.addListener(() => {
+        updateThemeUI();
+    });
+
+    document.addEventListener('inline-image-attachment-visibility-change', () => {
         updateThemeUI();
     });
 
@@ -267,6 +280,7 @@ function updateThemeUI() {
     const savedTheme = themeManager.getSavedTheme();
     const activeTheme = themeManager.getActiveTheme();
     const savedEmailTheme = themeManager.getSavedEmailTheme();
+    const inlineImageVisibility = getInlineImageAttachmentVisibility();
 
     // Update toggle button icon
     const sunIcon = document.getElementById('themeIconSun');
@@ -292,6 +306,10 @@ function updateThemeUI() {
 
     document.querySelectorAll('.theme-menu-item[data-type="email"]').forEach(item => {
         item.classList.toggle('active', item.dataset.theme === savedEmailTheme);
+    });
+
+    document.querySelectorAll('.theme-menu-item[data-type="inline-images"]').forEach(item => {
+        item.classList.toggle('active', item.dataset.inlineImages === inlineImageVisibility);
     });
 }
 

--- a/src/js/ui/AttachmentModalManager.js
+++ b/src/js/ui/AttachmentModalManager.js
@@ -22,11 +22,23 @@ export class AttachmentModalManager {
         this.attachmentModalContent = document.getElementById('attachmentModalContent');
         this.attachmentModalPrev = document.getElementById('attachmentModalPrev');
         this.attachmentModalNext = document.getElementById('attachmentModalNext');
+        this.attachmentModalZoomControls = document.getElementById('attachmentModalZoomControls');
+        this.attachmentModalZoomOut = document.getElementById('attachmentModalZoomOut');
+        this.attachmentModalZoomReset = document.getElementById('attachmentModalZoomReset');
+        this.attachmentModalZoomIn = document.getElementById('attachmentModalZoomIn');
+        this.attachmentModalZoomValue = document.getElementById('attachmentModalZoomValue');
 
         // Modal state
         this.currentAttachmentIndex = 0;
         this.previewableAttachments = [];
         this.currentAttachments = [];
+        this.imageZoomLevel = 1;
+        this.currentImagePreview = null;
+        this.minImageZoom = 1;
+        this.maxImageZoom = 6;
+        this.imageZoomStep = 0.25;
+        this.imageViewerFallbackWidth = 960;
+        this.imageViewerFallbackHeight = 720;
 
         // Navigation stack for nested content (e.g., attachments within nested emails)
         this.navigationStack = [];
@@ -196,6 +208,11 @@ export class AttachmentModalManager {
             }
             // In browser, let the default href/download behavior work
         });
+
+        this.attachmentModalZoomOut?.addEventListener('click', () => this.zoomOut());
+        this.attachmentModalZoomReset?.addEventListener('click', () => this.resetZoom());
+        this.attachmentModalZoomIn?.addEventListener('click', () => this.zoomIn());
+        this.attachmentModalContent?.addEventListener('wheel', (event) => this.handleModalWheel(event), { passive: false });
     }
 
     /**
@@ -366,6 +383,8 @@ export class AttachmentModalManager {
      * @param {Object} attachment - Attachment object to render
      */
     renderAttachmentPreview(attachment) {
+        this.resetImagePreviewState();
+
         // Set filename with breadcrumb if navigating from nested content
         this.updateFilenameWithBreadcrumb(attachment.fileName);
 
@@ -375,13 +394,11 @@ export class AttachmentModalManager {
 
         // Clear previous content
         this.attachmentModalContent.innerHTML = '';
+        this.attachmentModalContent.classList.remove('attachment-modal-content--image');
 
         // Render appropriate preview
         if (this.isPreviewableImage(attachment.attachMimeTag)) {
-            const img = document.createElement('img');
-            img.src = attachment.contentBase64;
-            img.alt = attachment.fileName;
-            this.attachmentModalContent.appendChild(img);
+            this.renderImagePreview(attachment);
         } else if (this.isPdf(attachment.attachMimeTag)) {
             // Use object tag for better PDF compatibility with data: URLs
             const pdfObject = document.createElement('object');
@@ -416,6 +433,193 @@ export class AttachmentModalManager {
 
         // Update navigation buttons
         this.updateNavButtons();
+    }
+
+    /**
+     * Renders an image preview with zoom support inside a fixed viewer area
+     * @param {Object} attachment - Image attachment to preview
+     */
+    renderImagePreview(attachment) {
+        const viewer = document.createElement('div');
+        viewer.className = 'attachment-image-viewer';
+
+        const stage = document.createElement('div');
+        stage.className = 'attachment-image-stage';
+
+        const img = document.createElement('img');
+        img.src = attachment.contentBase64;
+        img.alt = attachment.fileName;
+        img.className = 'attachment-preview-image';
+        img.draggable = false;
+
+        stage.appendChild(img);
+        viewer.appendChild(stage);
+        this.attachmentModalContent.classList.add('attachment-modal-content--image');
+        this.attachmentModalContent.appendChild(viewer);
+
+        this.currentImagePreview = { viewer, stage, image: img };
+        this.updateZoomControls();
+
+        img.addEventListener('load', () => {
+            this.applyImageZoom({ preserveViewport: false });
+        }, { once: true });
+
+        if (img.complete) {
+            queueMicrotask(() => this.applyImageZoom({ preserveViewport: false }));
+        }
+    }
+
+    /**
+     * Handles Ctrl/Cmd + wheel zoom for image previews
+     * @param {WheelEvent} event
+     */
+    handleModalWheel(event) {
+        if (!this.currentImagePreview || (!event.ctrlKey && !event.metaKey)) {
+            return;
+        }
+
+        event.preventDefault();
+        if (event.deltaY < 0) {
+            this.zoomIn();
+        } else if (event.deltaY > 0) {
+            this.zoomOut();
+        }
+    }
+
+    /**
+     * Zooms the current image in
+     */
+    zoomIn() {
+        this.setImageZoom(this.imageZoomLevel + this.imageZoomStep);
+    }
+
+    /**
+     * Zooms the current image out
+     */
+    zoomOut() {
+        this.setImageZoom(this.imageZoomLevel - this.imageZoomStep);
+    }
+
+    /**
+     * Resets the current image zoom to fit the viewer
+     */
+    resetZoom() {
+        this.setImageZoom(this.minImageZoom, { preserveViewport: false });
+    }
+
+    /**
+     * Updates the current image zoom level and re-renders the preview
+     * @param {number} nextZoomLevel - Requested zoom level
+     * @param {Object} [options]
+     * @param {boolean} [options.preserveViewport=true] - Keep current viewport center while zooming
+     */
+    setImageZoom(nextZoomLevel, { preserveViewport = true } = {}) {
+        if (!this.currentImagePreview) return;
+
+        const clampedZoom = Math.min(this.maxImageZoom, Math.max(this.minImageZoom, nextZoomLevel));
+        if (clampedZoom === this.imageZoomLevel && this.currentImagePreview.image?.style.width) {
+            this.updateZoomControls();
+            return;
+        }
+
+        this.imageZoomLevel = clampedZoom;
+        this.applyImageZoom({ preserveViewport });
+    }
+
+    /**
+     * Recomputes the image preview dimensions for the current zoom level
+     * @param {Object} [options]
+     * @param {boolean} [options.preserveViewport=true] - Keep current viewport center while zooming
+     */
+    applyImageZoom({ preserveViewport = true } = {}) {
+        if (!this.currentImagePreview) return;
+
+        const { viewer, stage, image } = this.currentImagePreview;
+        const naturalWidth = image.naturalWidth;
+        const naturalHeight = image.naturalHeight;
+
+        if (!naturalWidth || !naturalHeight) {
+            this.updateZoomControls();
+            return;
+        }
+
+        const { width: viewerWidth, height: viewerHeight } = this.getImageViewerSize(viewer);
+        const fitScale = Math.min(viewerWidth / naturalWidth, viewerHeight / naturalHeight);
+        const baseWidth = Math.max(1, Math.round(naturalWidth * fitScale));
+        const baseHeight = Math.max(1, Math.round(naturalHeight * fitScale));
+
+        const previousStageWidth = stage.scrollWidth || stage.clientWidth || viewerWidth;
+        const previousStageHeight = stage.scrollHeight || stage.clientHeight || viewerHeight;
+        const centerRatioX = preserveViewport ? (viewer.scrollLeft + (viewerWidth / 2)) / previousStageWidth : 0.5;
+        const centerRatioY = preserveViewport ? (viewer.scrollTop + (viewerHeight / 2)) / previousStageHeight : 0.5;
+
+        const scaledWidth = Math.max(1, Math.round(baseWidth * this.imageZoomLevel));
+        const scaledHeight = Math.max(1, Math.round(baseHeight * this.imageZoomLevel));
+        const stageWidth = Math.max(viewerWidth, scaledWidth);
+        const stageHeight = Math.max(viewerHeight, scaledHeight);
+
+        image.style.width = `${scaledWidth}px`;
+        image.style.height = `${scaledHeight}px`;
+        stage.style.width = `${stageWidth}px`;
+        stage.style.height = `${stageHeight}px`;
+
+        if (preserveViewport) {
+            viewer.scrollLeft = Math.max(0, Math.round((centerRatioX * stageWidth) - (viewerWidth / 2)));
+            viewer.scrollTop = Math.max(0, Math.round((centerRatioY * stageHeight) - (viewerHeight / 2)));
+        } else {
+            viewer.scrollLeft = Math.max(0, Math.round((stageWidth - viewerWidth) / 2));
+            viewer.scrollTop = Math.max(0, Math.round((stageHeight - viewerHeight) / 2));
+        }
+
+        this.updateZoomControls();
+    }
+
+    /**
+     * Returns the current image viewer dimensions with test-friendly fallbacks
+     * @param {HTMLElement} viewer - Viewer element
+     * @returns {{width: number, height: number}}
+     */
+    getImageViewerSize(viewer) {
+        return {
+            width: viewer?.clientWidth || this.imageViewerFallbackWidth,
+            height: viewer?.clientHeight || this.imageViewerFallbackHeight
+        };
+    }
+
+    /**
+     * Resets image-specific preview state
+     */
+    resetImagePreviewState() {
+        this.imageZoomLevel = this.minImageZoom;
+        this.currentImagePreview = null;
+        this.updateZoomControls();
+    }
+
+    /**
+     * Updates the zoom controls visibility and disabled state
+     */
+    updateZoomControls() {
+        const hasImagePreview = Boolean(this.currentImagePreview);
+
+        if (this.attachmentModalZoomControls) {
+            this.attachmentModalZoomControls.hidden = !hasImagePreview;
+        }
+
+        if (this.attachmentModalZoomValue) {
+            this.attachmentModalZoomValue.textContent = `${Math.round(this.imageZoomLevel * 100)}%`;
+        }
+
+        if (this.attachmentModalZoomOut) {
+            this.attachmentModalZoomOut.disabled = !hasImagePreview || this.imageZoomLevel <= this.minImageZoom;
+        }
+
+        if (this.attachmentModalZoomReset) {
+            this.attachmentModalZoomReset.disabled = !hasImagePreview || this.imageZoomLevel === this.minImageZoom;
+        }
+
+        if (this.attachmentModalZoomIn) {
+            this.attachmentModalZoomIn.disabled = !hasImagePreview || this.imageZoomLevel >= this.maxImageZoom;
+        }
     }
 
     /**
@@ -796,7 +1000,9 @@ export class AttachmentModalManager {
 
         this.attachmentModal.classList.remove('active');
         this.attachmentModalContent.innerHTML = '';
+        this.attachmentModalContent.classList.remove('attachment-modal-content--image');
         this.clearNavigationStack();
+        this.resetImagePreviewState();
 
         // Restore body scroll
         document.body.style.overflow = '';

--- a/src/js/ui/AttachmentModalManager.js
+++ b/src/js/ui/AttachmentModalManager.js
@@ -27,6 +27,7 @@ export class AttachmentModalManager {
         this.attachmentModalZoomReset = document.getElementById('attachmentModalZoomReset');
         this.attachmentModalZoomIn = document.getElementById('attachmentModalZoomIn');
         this.attachmentModalZoomValue = document.getElementById('attachmentModalZoomValue');
+        this.attachmentModalSourceLink = document.getElementById('attachmentModalSourceLink');
 
         // Modal state
         this.currentAttachmentIndex = 0;
@@ -39,6 +40,7 @@ export class AttachmentModalManager {
         this.imageZoomStep = 0.25;
         this.imageViewerFallbackWidth = 960;
         this.imageViewerFallbackHeight = 720;
+        this.inlineImageMetadataBySource = new Map();
 
         // Navigation stack for nested content (e.g., attachments within nested emails)
         this.navigationStack = [];
@@ -97,8 +99,12 @@ export class AttachmentModalManager {
      * @param {string} [options.fileName] - Suggested file name for the modal header/download
      * @returns {boolean} True when an image source was provided
      */
-    openInlineImage({ source, fileName = 'inline-image' }) {
+    openInlineImage({ source, fileName = 'inline-image', linkHref = '' }) {
         if (!source) return false;
+
+        if (linkHref) {
+            this.setInlineImageMetadata(source, { linkHref });
+        }
 
         const matchedAttachment = this.findAttachmentBySource(source);
         const attachment = matchedAttachment || this.createInlineImageAttachment(source, fileName);
@@ -109,6 +115,21 @@ export class AttachmentModalManager {
 
         this.open(attachment);
         return true;
+    }
+
+    /**
+     * Stores metadata for inline images so preview entry-points can share context
+     * @param {string} source - Rendered image source URL or data URI
+     * @param {Object} metadata - Metadata associated with the inline image
+     */
+    setInlineImageMetadata(source, metadata = {}) {
+        if (!source) return;
+
+        const existingMetadata = this.inlineImageMetadataBySource.get(source) || {};
+        this.inlineImageMetadataBySource.set(source, {
+            ...existingMetadata,
+            ...metadata
+        });
     }
 
     /**
@@ -387,6 +408,7 @@ export class AttachmentModalManager {
 
         // Set filename with breadcrumb if navigating from nested content
         this.updateFilenameWithBreadcrumb(attachment.fileName);
+        this.updateSourceLink(this.inlineImageMetadataBySource.get(attachment.contentBase64)?.linkHref || '');
 
         // Set download link
         this.attachmentModalDownload.href = attachment.contentBase64;
@@ -584,6 +606,23 @@ export class AttachmentModalManager {
             width: viewer?.clientWidth || this.imageViewerFallbackWidth,
             height: viewer?.clientHeight || this.imageViewerFallbackHeight
         };
+    }
+
+    /**
+     * Updates the optional source-link action for linked inline images
+     * @param {string} linkHref - Original link target wrapping the inline image
+     */
+    updateSourceLink(linkHref) {
+        if (!this.attachmentModalSourceLink) return;
+
+        if (!linkHref) {
+            this.attachmentModalSourceLink.hidden = true;
+            this.attachmentModalSourceLink.removeAttribute('href');
+            return;
+        }
+
+        this.attachmentModalSourceLink.href = linkHref;
+        this.attachmentModalSourceLink.hidden = false;
     }
 
     /**
@@ -1003,6 +1042,7 @@ export class AttachmentModalManager {
         this.attachmentModalContent.classList.remove('attachment-modal-content--image');
         this.clearNavigationStack();
         this.resetImagePreviewState();
+        this.updateSourceLink('');
 
         // Restore body scroll
         document.body.style.overflow = '';

--- a/src/js/ui/MessageContentRenderer.js
+++ b/src/js/ui/MessageContentRenderer.js
@@ -202,7 +202,7 @@ export class MessageContentRenderer {
      * @returns {boolean}
      */
     getShowInlineImagesPreference() {
-        return storage.get(INLINE_IMAGES_PREFERENCE_KEY, false) === true;
+        return storage.get(INLINE_IMAGES_PREFERENCE_KEY, true) !== false;
     }
 
     /**

--- a/src/js/ui/MessageContentRenderer.js
+++ b/src/js/ui/MessageContentRenderer.js
@@ -22,6 +22,8 @@ export class MessageContentRenderer {
         this.container = containerElement;
         this.messageHandler = messageHandler;
         this.attachmentModal = attachmentModal;
+        this.realAttachments = [];
+        this.inlineImageAttachments = [];
 
         this.initInlineImageEventListeners();
         this.initInlineAttachmentPreferenceListener();
@@ -242,6 +244,7 @@ export class MessageContentRenderer {
             toggleLabel.textContent = expanded ? 'Hide' : 'Show';
         }
         sectionContent.hidden = !expanded;
+        this.updateAttachmentModalAttachments(expanded);
     }
 
     /**
@@ -367,16 +370,19 @@ export class MessageContentRenderer {
     renderAttachments(msgInfo) {
         if (!msgInfo.attachments?.length) return '';
 
-        // Store attachments in modal manager for access
-        if (this.attachmentModal) {
-            this.attachmentModal.setAttachments(msgInfo.attachments);
-        }
+        this.realAttachments = msgInfo.attachments.filter(attachment => !isInlineImageAttachment(attachment));
+        this.inlineImageAttachments = msgInfo.attachments.filter(attachment => isInlineImageAttachment(attachment));
 
-        const attachmentsWithIndex = msgInfo.attachments.map((attachment, index) => ({ attachment, index }));
-        const visibleAttachments = attachmentsWithIndex.filter(({ attachment }) => !isInlineImageAttachment(attachment));
-        const inlineImageAttachments = attachmentsWithIndex.filter(({ attachment }) => isInlineImageAttachment(attachment));
+        if (this.realAttachments.length === 0 && this.inlineImageAttachments.length === 0) return '';
 
-        if (visibleAttachments.length === 0 && inlineImageAttachments.length === 0) return '';
+        const inlineExpandedByDefault = inlineImageAttachmentsExpandedByDefault();
+        this.updateAttachmentModalAttachments(inlineExpandedByDefault);
+
+        const visibleAttachments = this.realAttachments.map((attachment, index) => ({ attachment, index }));
+        const inlineImageAttachments = this.inlineImageAttachments.map((attachment, index) => ({
+            attachment,
+            index: this.realAttachments.length + index
+        }));
 
         return `
             <div class="mt-6">
@@ -403,6 +409,20 @@ export class MessageContentRenderer {
                 </div>
             </div>
         `;
+    }
+
+    /**
+     * Syncs modal navigation order with the currently visible attachment sections
+     * @param {boolean} includeInlineImages - Whether inline image attachments are part of the modal sequence
+     */
+    updateAttachmentModalAttachments(includeInlineImages) {
+        if (!this.attachmentModal?.setAttachments) return;
+
+        const attachments = includeInlineImages
+            ? [...this.realAttachments, ...this.inlineImageAttachments]
+            : [...this.realAttachments];
+
+        this.attachmentModal.setAttachments(attachments);
     }
 
     /**

--- a/src/js/ui/MessageContentRenderer.js
+++ b/src/js/ui/MessageContentRenderer.js
@@ -1,6 +1,11 @@
 import { sanitizeHTML } from '../sanitizer.js';
 import { parseColor, getContrastRatio, adjustColorForContrast } from '../colorUtils.js';
 import { isInlineImageAttachment } from '../helpers.js';
+import {
+    INLINE_IMAGE_ATTACHMENT_VISIBILITY,
+    inlineImageAttachmentsExpandedByDefault,
+    setInlineImageAttachmentVisibility
+} from '../InlineImagePreference.js';
 
 /**
  * Renders message content in the main viewer area
@@ -19,6 +24,7 @@ export class MessageContentRenderer {
         this.attachmentModal = attachmentModal;
 
         this.initInlineImageEventListeners();
+        this.initInlineAttachmentPreferenceListener();
     }
 
     /**
@@ -97,6 +103,13 @@ export class MessageContentRenderer {
         this.container.addEventListener('click', (event) => {
             if (!(event.target instanceof Element)) return;
 
+            const inlineImagesToggle = event.target.closest('[data-inline-images-toggle]');
+            if (inlineImagesToggle && this.container.contains(inlineImagesToggle)) {
+                event.preventDefault();
+                this.toggleInlineImageSection(inlineImagesToggle);
+                return;
+            }
+
             const image = event.target.closest('img[data-inline-image-previewable="true"]');
             if (!image || !this.container.contains(image)) return;
 
@@ -113,6 +126,20 @@ export class MessageContentRenderer {
 
             event.preventDefault();
             this.openInlineImage(image);
+        });
+    }
+
+    /**
+     * Reacts to global inline-image preference changes from the settings menu
+     */
+    initInlineAttachmentPreferenceListener() {
+        document.addEventListener('inline-image-attachment-visibility-change', (event) => {
+            const nextVisibility = event.detail?.visibility;
+            if (!nextVisibility) return;
+
+            this.applyInlineImageSectionState(
+                nextVisibility === INLINE_IMAGE_ATTACHMENT_VISIBILITY.EXPANDED
+            );
         });
     }
 
@@ -135,13 +162,19 @@ export class MessageContentRenderer {
                 attachment.attachMimeTag?.toLowerCase().startsWith('image/') &&
                 attachment.contentBase64 === source
             );
+            const linkHref = image.closest('a[href]')?.getAttribute('href') || '';
             const fileName = matchingAttachment?.fileName || image.getAttribute('alt') || `inline-image-${index + 1}`;
             const contentId = matchingAttachment?.pidContentId || matchingAttachment?.contentId || '';
+
+            if (linkHref && this.attachmentModal?.setInlineImageMetadata) {
+                this.attachmentModal.setInlineImageMetadata(source, { linkHref });
+            }
 
             image.dataset.inlineImagePreviewable = 'true';
             image.dataset.inlineImageSource = source;
             image.dataset.inlineImageFilename = fileName;
             image.dataset.inlineImageContentId = contentId;
+            image.dataset.inlineImageLinkHref = linkHref;
             image.tabIndex = image.tabIndex >= 0 ? image.tabIndex : 0;
             image.style.cursor = 'zoom-in';
             image.setAttribute('role', 'button');
@@ -165,7 +198,50 @@ export class MessageContentRenderer {
         if (!source || !this.attachmentModal?.openInlineImage) return;
 
         const fileName = image.dataset.inlineImageFilename || image.getAttribute('alt') || 'inline-image';
-        this.attachmentModal.openInlineImage({ source, fileName });
+        const linkHref = image.dataset.inlineImageLinkHref || '';
+        this.attachmentModal.openInlineImage({ source, fileName, linkHref });
+    }
+
+    /**
+     * Toggles the inline-image attachment section and persists the new preference
+     * @param {HTMLElement} toggleButton - Toggle button in the section header
+     */
+    toggleInlineImageSection(toggleButton) {
+        const isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+        const nextExpanded = !isExpanded;
+
+        setInlineImageAttachmentVisibility(
+            nextExpanded
+                ? INLINE_IMAGE_ATTACHMENT_VISIBILITY.EXPANDED
+                : INLINE_IMAGE_ATTACHMENT_VISIBILITY.COLLAPSED
+        );
+
+        this.applyInlineImageSectionState(nextExpanded);
+        document.dispatchEvent(new CustomEvent('inline-image-attachment-visibility-change', {
+            detail: {
+                visibility: nextExpanded
+                    ? INLINE_IMAGE_ATTACHMENT_VISIBILITY.EXPANDED
+                    : INLINE_IMAGE_ATTACHMENT_VISIBILITY.COLLAPSED
+            }
+        }));
+    }
+
+    /**
+     * Updates the inline-image section UI to match the current expanded state
+     * @param {boolean} expanded - Whether inline images should be shown
+     */
+    applyInlineImageSectionState(expanded) {
+        const toggleButton = this.container?.querySelector('[data-inline-images-toggle]');
+        const toggleLabel = this.container?.querySelector('[data-inline-images-toggle-label]');
+        const sectionContent = this.container?.querySelector('[data-inline-images-content]');
+
+        if (!toggleButton || !sectionContent) return;
+
+        toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (toggleLabel) {
+            toggleLabel.textContent = expanded ? 'Hide' : 'Show';
+        }
+        sectionContent.hidden = !expanded;
     }
 
     /**
@@ -296,107 +372,184 @@ export class MessageContentRenderer {
             this.attachmentModal.setAttachments(msgInfo.attachments);
         }
 
-        const visibleAttachments = msgInfo.attachments
-            .map((attachment, index) => ({ attachment, index }))
-            .filter(({ attachment }) => !isInlineImageAttachment(attachment));
+        const attachmentsWithIndex = msgInfo.attachments.map((attachment, index) => ({ attachment, index }));
+        const visibleAttachments = attachmentsWithIndex.filter(({ attachment }) => !isInlineImageAttachment(attachment));
+        const inlineImageAttachments = attachmentsWithIndex.filter(({ attachment }) => isInlineImageAttachment(attachment));
 
-        if (visibleAttachments.length === 0) return '';
+        if (visibleAttachments.length === 0 && inlineImageAttachments.length === 0) return '';
 
         return `
             <div class="mt-6">
                 <hr class="attachments-divider border-t mb-4">
-                <div class="flex items-center gap-2 mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 attachment-icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
-                    </svg>
-                    <span class="attachment-label">${visibleAttachments.length} ${visibleAttachments.length === 1 ? 'Attachment' : 'Attachments'}</span>
+                <div class="attachment-sections">
+                    ${visibleAttachments.length > 0
+        ? this.renderAttachmentSection({
+            items: visibleAttachments,
+            label: `${visibleAttachments.length} ${visibleAttachments.length === 1 ? 'Attachment' : 'Attachments'}`,
+            icon: this.getAttachmentSectionIcon(),
+            sectionClassName: 'attachment-section'
+        })
+        : ''}
+                    ${inlineImageAttachments.length > 0
+        ? this.renderAttachmentSection({
+            items: inlineImageAttachments,
+            label: `${inlineImageAttachments.length} ${inlineImageAttachments.length === 1 ? 'Inline image' : 'Inline images'}`,
+            icon: this.getInlineImageSectionIcon(),
+            sectionClassName: 'attachment-section attachment-section-inline',
+            collapsible: true,
+            collapsed: !inlineImageAttachmentsExpandedByDefault()
+        })
+        : ''}
                 </div>
-                <div class="flex flex-wrap gap-4">
-                    ${visibleAttachments.map(({ attachment, index }) => {
-        const isPreviewable = this.attachmentModal?.isPreviewable(attachment.attachMimeTag);
+            </div>
+        `;
+    }
+
+    /**
+     * Renders a single attachment section
+     * @param {Object} options
+     * @param {Array} options.items - Attachment entries with original indices
+     * @param {string} options.label - Section label
+     * @param {string} options.icon - Section icon markup
+     * @param {string} options.sectionClassName - CSS classes for the section
+     * @param {boolean} [options.collapsible=false] - Whether the section can be collapsed
+     * @param {boolean} [options.collapsed=false] - Whether the section starts collapsed
+     * @returns {string} Rendered HTML
+     */
+    renderAttachmentSection({ items, label, icon, sectionClassName, collapsible = false, collapsed = false }) {
+        const expanded = !collapsed;
+
+        return `
+            <section class="${sectionClassName}">
+                <div class="attachment-section-header">
+                    <div class="attachment-section-summary">
+                        ${icon}
+                        <span class="attachment-label">${label}</span>
+                    </div>
+                    ${collapsible
+        ? `<button type="button"
+                               class="attachment-section-toggle"
+                               data-inline-images-toggle
+                               aria-expanded="${expanded ? 'true' : 'false'}">
+                            <span data-inline-images-toggle-label>${expanded ? 'Hide' : 'Show'}</span>
+                        </button>`
+        : ''}
+                </div>
+                <div class="flex flex-wrap gap-4" ${collapsible ? 'data-inline-images-content' : ''} ${collapsed ? 'hidden' : ''}>
+                    ${this.renderAttachmentItems(items)}
+                </div>
+            </section>
+        `;
+    }
+
+    /**
+     * Renders attachment cards for a section
+     * @param {Array} items - Attachment entries with original indices
+     * @returns {string} Card markup
+     */
+    renderAttachmentItems(items) {
+        return items.map(({ attachment, index }) => {
+            const isPreviewable = this.attachmentModal?.isPreviewable(attachment.attachMimeTag);
+
+            if (isPreviewable) {
+                return `
+                    <div class="cursor-pointer min-w-[250px] max-w-fit"
+                         data-action="preview"
+                         data-attachment-index="${index}"
+                         title="Click to preview">
+                        <div class="attachment-item flex items-center space-x-2">
+                            <div class="attachment-thumbnail w-10 h-10 shrink-0 flex items-center justify-center overflow-hidden">
+                                ${this.getAttachmentItemIcon(attachment)}
+                            </div>
+                            <div>
+                                <p class="attachment-filename">${attachment.fileName}</p>
+                                <p class="attachment-meta">${attachment.attachMimeTag} - ${attachment.contentLength} bytes</p>
+                            </div>
+                            <button data-action="download"
+                                    data-attachment-index="${index}"
+                                    class="ml-auto pl-2 attachment-download-btn"
+                                    title="Download">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                `;
+            }
+
+            return `
+                <div class="cursor-pointer min-w-[250px] max-w-fit"
+                     data-action="download"
+                     data-attachment-index="${index}"
+                     title="Click to download">
+                    <div class="attachment-item flex items-center space-x-2">
+                        <div class="attachment-thumbnail w-10 h-10 shrink-0 flex items-center justify-center overflow-hidden">
+                            ${this.getAttachmentItemIcon(attachment)}
+                        </div>
+                        <div>
+                            <p class="attachment-filename">${attachment.fileName}</p>
+                            <p class="attachment-meta">${attachment.attachMimeTag} - ${attachment.contentLength} bytes</p>
+                        </div>
+                        <div class="ml-auto pl-2 attachment-download-btn">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    /**
+     * Returns the appropriate icon markup for an attachment item
+     * @param {Object} attachment - Attachment object
+     * @returns {string} Icon HTML
+     */
+    getAttachmentItemIcon(attachment) {
         const isImage = this.attachmentModal?.isPreviewableImage(attachment.attachMimeTag);
         const isPdf = this.attachmentModal?.isPdf(attachment.attachMimeTag);
         const isText = this.attachmentModal?.isText(attachment.attachMimeTag);
         const isEml = this.attachmentModal?.isPreviewableEml(attachment.attachMimeTag);
 
-        // Icon selection helper
-        const getIcon = () => {
-            if (isImage) {
-                return `<img src="${attachment.contentBase64}" alt="Attachment" class="w-10 h-10 object-cover">`;
-            } else if (isPdf) {
-                return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-red-500">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-                                </svg>`;
-            } else if (isText) {
-                return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 attachment-icon">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-                                </svg>`;
-            } else if (isEml) {
-                return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-blue-500">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
-                                </svg>`;
-            }
-            return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 attachment-icon">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-                            </svg>`;
-        };
-
-        if (isPreviewable) {
-            // Previewable files: click opens modal
-            return `
-                                <div class="cursor-pointer min-w-[250px] max-w-fit"
-                                     data-action="preview"
-                                     data-attachment-index="${index}"
-                                     title="Click to preview">
-                                    <div class="attachment-item flex items-center space-x-2">
-                                        <div class="attachment-thumbnail w-10 h-10 shrink-0 flex items-center justify-center overflow-hidden">
-                                            ${getIcon()}
-                                        </div>
-                                        <div>
-                                            <p class="attachment-filename">${attachment.fileName}</p>
-                                            <p class="attachment-meta">${attachment.attachMimeTag} - ${attachment.contentLength} bytes</p>
-                                        </div>
-                                        <button data-action="download"
-                                                data-attachment-index="${index}"
-                                                class="ml-auto pl-2 attachment-download-btn"
-                                                title="Download">
-                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                            `;
-        } else {
-            // Non-previewable files: click to download
-            return `
-                                <div class="cursor-pointer min-w-[250px] max-w-fit"
-                                     data-action="download"
-                                     data-attachment-index="${index}"
-                                     title="Click to download">
-                                    <div class="attachment-item flex items-center space-x-2">
-                                        <div class="attachment-thumbnail w-10 h-10 shrink-0 flex items-center justify-center">
-                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 attachment-icon">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-                                            </svg>
-                                        </div>
-                                        <div>
-                                            <p class="attachment-filename">${attachment.fileName}</p>
-                                            <p class="attachment-meta">${attachment.attachMimeTag} - ${attachment.contentLength} bytes</p>
-                                        </div>
-                                        <div class="ml-auto pl-2 attachment-download-btn">
-                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-                                            </svg>
-                                        </div>
-                                    </div>
-                                </div>
-                            `;
+        if (isImage) {
+            return `<img src="${attachment.contentBase64}" alt="Attachment" class="w-10 h-10 object-cover">`;
         }
-    }).join('')}
-                </div>
-            </div>
-        `;
+
+        if (isPdf) {
+            return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-red-500">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                    </svg>`;
+        }
+
+        if (isText) {
+            return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 attachment-icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                    </svg>`;
+        }
+
+        if (isEml) {
+            return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-blue-500">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+                    </svg>`;
+        }
+
+        return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 attachment-icon">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                </svg>`;
+    }
+
+    getAttachmentSectionIcon() {
+        return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 attachment-icon">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
+                </svg>`;
+    }
+
+    getInlineImageSectionIcon() {
+        return `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 attachment-icon">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.159 2.159M3.75 19.5h16.5A1.5 1.5 0 0 0 21.75 18V6A1.5 1.5 0 0 0 20.25 4.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm11.25-10.5h.008v.008H15V9Z" />
+                </svg>`;
     }
 }
 

--- a/src/js/ui/MessageContentRenderer.js
+++ b/src/js/ui/MessageContentRenderer.js
@@ -1,9 +1,6 @@
 import { sanitizeHTML } from '../sanitizer.js';
 import { parseColor, getContrastRatio, adjustColorForContrast } from '../colorUtils.js';
-import { storage } from '../storage.js';
 import { isInlineImageAttachment } from '../helpers.js';
-
-const INLINE_IMAGES_PREFERENCE_KEY = 'msgReader_showInlineImages';
 
 /**
  * Renders message content in the main viewer area
@@ -100,13 +97,6 @@ export class MessageContentRenderer {
         this.container.addEventListener('click', (event) => {
             if (!(event.target instanceof Element)) return;
 
-            const toggleButton = event.target.closest('[data-action="toggle-inline-images"]');
-            if (toggleButton && this.container.contains(toggleButton)) {
-                event.preventDefault();
-                this.toggleInlineImages();
-                return;
-            }
-
             const image = event.target.closest('img[data-inline-image-previewable="true"]');
             if (!image || !this.container.contains(image)) return;
 
@@ -134,7 +124,6 @@ export class MessageContentRenderer {
         const emailContent = this.container?.querySelector('.email-content');
         if (!emailContent) return;
 
-        emailContent.dataset.showInlineImages = this.getShowInlineImagesPreference() ? 'true' : 'false';
         const attachments = msgInfo.attachments || [];
         const images = emailContent.querySelectorAll('img[src]');
 
@@ -164,11 +153,7 @@ export class MessageContentRenderer {
             if (!image.getAttribute('aria-label')) {
                 image.setAttribute('aria-label', `Open ${fileName} in preview`);
             }
-
-            this.applyInlineImageVisibility(image);
         });
-
-        this.updateInlineImagesUI(images.length);
     }
 
     /**
@@ -181,99 +166,6 @@ export class MessageContentRenderer {
 
         const fileName = image.dataset.inlineImageFilename || image.getAttribute('alt') || 'inline-image';
         this.attachmentModal.openInlineImage({ source, fileName });
-    }
-
-    /**
-     * Applies the persisted inline-image visibility preference to a single image
-     * @param {HTMLImageElement} image - Image element to update
-     */
-    applyInlineImageVisibility(image) {
-        const emailContent = this.container?.querySelector('.email-content');
-        const shouldShowInlineImages = emailContent?.dataset.showInlineImages === 'true';
-        const shouldHide = !shouldShowInlineImages;
-
-        image.hidden = shouldHide;
-        image.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
-        image.tabIndex = shouldHide ? -1 : 0;
-    }
-
-    /**
-     * Gets the persisted user preference for inline images
-     * @returns {boolean}
-     */
-    getShowInlineImagesPreference() {
-        return storage.get(INLINE_IMAGES_PREFERENCE_KEY, true) !== false;
-    }
-
-    /**
-     * Persists the inline-images preference
-     * @param {boolean} value - Whether inline images should be shown
-     */
-    setShowInlineImagesPreference(value) {
-        storage.set(INLINE_IMAGES_PREFERENCE_KEY, value);
-    }
-
-    /**
-     * Refreshes the show/hide toggle for inline images
-     * @param {number} inlineImageCount - Number of inline images in the current message
-     */
-    updateInlineImagesUI(inlineImageCount) {
-        const emailContent = this.container?.querySelector('.email-content');
-        if (!emailContent) return;
-
-        const existingToggle = this.container.querySelector('.inline-image-toggle');
-
-        if (inlineImageCount === 0) {
-            existingToggle?.remove();
-            return;
-        }
-
-        const toggle = existingToggle || this.createInlineImagesToggle();
-        const expanded = emailContent.dataset.showInlineImages === 'true';
-        const label = `${inlineImageCount} inline image${inlineImageCount === 1 ? '' : 's'} ${expanded ? 'shown' : 'hidden'}`;
-
-        toggle.querySelector('.inline-image-toggle-label').textContent = label;
-        const button = toggle.querySelector('[data-action="toggle-inline-images"]');
-        button.textContent = expanded ? 'Hide inline images' : 'Show inline images';
-        button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    }
-
-    /**
-     * Creates the toggle element used to reveal/collapse inline images
-     * @returns {HTMLDivElement}
-     */
-    createInlineImagesToggle() {
-        const toggle = document.createElement('div');
-        toggle.className = 'inline-image-toggle';
-        toggle.innerHTML = `
-            <span class="inline-image-toggle-label"></span>
-            <button type="button" class="inline-image-toggle-button" data-action="toggle-inline-images" aria-expanded="false">
-                Show inline images
-            </button>
-        `;
-
-        const emailContent = this.container?.querySelector('.email-content');
-        emailContent?.insertAdjacentElement('beforebegin', toggle);
-        return toggle;
-    }
-
-    /**
-     * Toggles visibility of inline images for the current user and persists the choice
-     */
-    toggleInlineImages() {
-        const emailContent = this.container?.querySelector('.email-content');
-        if (!emailContent) return;
-
-        const expanded = emailContent.dataset.showInlineImages === 'true';
-        const nextValue = !expanded;
-        emailContent.dataset.showInlineImages = nextValue ? 'true' : 'false';
-        this.setShowInlineImagesPreference(nextValue);
-
-        emailContent.querySelectorAll('img[data-inline-image-previewable="true"]').forEach(image => {
-            this.applyInlineImageVisibility(image);
-        });
-
-        this.updateInlineImagesUI(emailContent.querySelectorAll('img[data-inline-image-previewable="true"]').length);
     }
 
     /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -565,8 +565,11 @@
         position: relative;
         display: flex;
         flex-direction: column;
-        max-width: 90vw;
-        max-height: 90vh;
+        width: min(92vw, 1180px);
+        min-width: min(92vw, 720px);
+        min-height: min(78vh, 760px);
+        max-width: 92vw;
+        max-height: 92vh;
         background-color: var(--surface-color);
         border-radius: 1rem;
         overflow: hidden;
@@ -620,6 +623,51 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
+    }
+
+    .attachment-modal-zoom-controls {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        background-color: color-mix(in srgb, var(--surface-color) 88%, transparent);
+    }
+
+    .attachment-modal-zoom-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2.25rem;
+        height: 2.25rem;
+        padding: 0 0.625rem;
+        border: none;
+        border-radius: 999px;
+        background: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .attachment-modal-zoom-button:hover:not(:disabled) {
+        background-color: var(--hover-bg);
+        color: var(--text-primary);
+    }
+
+    .attachment-modal-zoom-button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+    }
+
+    .attachment-modal-zoom-reset {
+        min-width: 4.5rem;
+    }
+
+    .attachment-modal-zoom-value {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
     }
 
     .attachment-modal-download {
@@ -676,19 +724,49 @@
 
     .attachment-modal-content {
         display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
+        flex: 1;
+        align-items: stretch;
+        justify-content: stretch;
+        padding: 0.75rem;
         overflow: auto;
         min-width: 300px;
-        min-height: 200px;
+        min-height: min(70vh, 680px);
         background-color: var(--surface-color);
     }
 
-    .attachment-modal-content img {
-        max-width: 85vw;
-        max-height: 80vh;
+    .attachment-modal-content--image {
+        padding: 0;
+        background:
+            radial-gradient(circle at top left, color-mix(in srgb, var(--surface-tertiary) 82%, transparent), transparent 45%),
+            linear-gradient(180deg, color-mix(in srgb, var(--surface-tertiary) 72%, transparent), var(--surface-color));
+    }
+
+    .attachment-image-viewer {
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+    }
+
+    .attachment-image-stage {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 100%;
+        min-height: 100%;
+        padding: 2rem;
+        box-sizing: border-box;
+    }
+
+    .attachment-preview-image {
+        display: block;
+        max-width: none;
+        max-height: none;
+        width: auto;
+        height: auto;
         object-fit: contain;
+        border-radius: 0.75rem;
+        box-shadow: 0 24px 60px -36px rgb(15 23 42 / 0.55);
+        user-select: none;
     }
 
     .attachment-modal-content:has(iframe),
@@ -735,6 +813,39 @@
 
     .attachment-modal-nav-next {
         right: calc(50% - 45vw - 4rem);
+    }
+
+    @media (max-width: 768px) {
+        .attachment-modal-container {
+            width: 96vw;
+            min-width: 96vw;
+            min-height: 72vh;
+            max-height: 94vh;
+            border-radius: 0.875rem;
+        }
+
+        .attachment-modal-header {
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            align-items: flex-start;
+        }
+
+        .attachment-modal-filename {
+            order: 2;
+            width: 100%;
+        }
+
+        .attachment-modal-actions {
+            margin-left: auto;
+        }
+
+        .attachment-modal-content {
+            min-height: 60vh;
+        }
+
+        .attachment-image-stage {
+            padding: 1rem;
+        }
     }
 
     .attachment-text-preview {

--- a/src/styles.css
+++ b/src/styles.css
@@ -308,8 +308,67 @@
         border-color: var(--border-color);
     }
 
+    .message-card .attachment-sections {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .message-card .attachment-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .message-card .attachment-section-inline {
+        padding: 0.875rem 1rem;
+        border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
+        border-radius: 1rem;
+        background: color-mix(in srgb, var(--surface-secondary) 72%, transparent);
+    }
+
+    .message-card .attachment-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+    }
+
+    .message-card .attachment-section-summary {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
     .message-card .attachment-label {
         color: var(--text-secondary);
+        font-size: 0.9rem;
+        font-weight: 600;
+    }
+
+    .message-card .attachment-section-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.4rem 0.8rem;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        background-color: var(--surface-color);
+        color: var(--text-secondary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.15s;
+    }
+
+    .message-card .attachment-section-toggle:hover {
+        background-color: var(--hover-bg);
+        color: var(--text-primary);
+    }
+
+    .message-card [data-inline-images-content][hidden] {
+        display: none !important;
     }
 
     .message-card .attachment-item {
@@ -685,6 +744,26 @@
         color: var(--primary-color);
     }
 
+    .attachment-modal-source-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem 0.875rem;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        color: var(--text-secondary);
+        background-color: color-mix(in srgb, var(--surface-color) 90%, transparent);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        text-decoration: none;
+        transition: all 0.2s;
+    }
+
+    .attachment-modal-source-link:hover {
+        background-color: var(--hover-bg);
+        color: var(--text-primary);
+    }
+
     .attachment-modal-back {
         display: flex;
         align-items: center;
@@ -735,6 +814,9 @@
     }
 
     .attachment-modal-content--image {
+        display: flex;
+        align-items: stretch;
+        justify-content: stretch;
         padding: 0;
         background:
             radial-gradient(circle at top left, color-mix(in srgb, var(--surface-tertiary) 82%, transparent), transparent 45%),
@@ -742,8 +824,10 @@
     }
 
     .attachment-image-viewer {
+        display: flex;
+        flex: 1;
         width: 100%;
-        height: 100%;
+        min-height: 0;
         overflow: auto;
     }
 
@@ -754,6 +838,7 @@
         min-width: 100%;
         min-height: 100%;
         padding: 2rem;
+        margin: auto;
         box-sizing: border-box;
     }
 

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -1113,6 +1113,17 @@ describe('MessageContentRenderer', () => {
             expect(mockModal.setAttachments).toHaveBeenCalledWith(attachments);
         });
 
+        test('keeps inline images out of the modal sequence while the section is collapsed', () => {
+            const attachments = [
+                { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
+                { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:inline' }
+            ];
+
+            renderer.renderAttachments({ attachments });
+
+            expect(mockModal.setAttachments).toHaveBeenCalledWith([attachments[0]]);
+        });
+
         test('renders attachment count', () => {
             expect(renderer.renderAttachments({ attachments: [{ fileName: 'a.pdf' }] })).toContain('1 Attachment');
         });
@@ -1145,7 +1156,10 @@ describe('MessageContentRenderer', () => {
 
         test('persists inline image section visibility when toggled', () => {
             renderer.render(createMockMessage({
-                attachments: [{ fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }]
+                attachments: [
+                    { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
+                    { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }
+                ]
             }));
 
             const toggle = container.querySelector('[data-inline-images-toggle]');
@@ -1159,6 +1173,10 @@ describe('MessageContentRenderer', () => {
             expect(toggle.getAttribute('aria-expanded')).toBe('true');
             expect(content.hidden).toBe(false);
             expect(JSON.parse(window.localStorage.getItem('msgReader_inlineImageAttachments'))).toBe('expanded');
+            expect(mockModal.setAttachments).toHaveBeenLastCalledWith([
+                { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
+                { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }
+            ]);
         });
     });
 });

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -930,7 +930,6 @@ describe('MessageContentRenderer', () => {
     });
 
     test('clicking inline images opens the modal preview', () => {
-        window.localStorage.setItem('msgReader_showInlineImages', JSON.stringify(true));
         const inlineImage = 'data:image/png;base64,abc';
         renderer.render(createMockMessage({
             bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image"></p>`,
@@ -945,7 +944,7 @@ describe('MessageContentRenderer', () => {
         });
     });
 
-    test('shows inline images by default and shows a toggle', () => {
+    test('always shows inline images in the message body', () => {
         const iconImage = 'data:image/png;base64,icon';
         const screenshotImage = 'data:image/png;base64,screen';
 
@@ -965,53 +964,7 @@ describe('MessageContentRenderer', () => {
         const images = container.querySelectorAll('.email-content img');
         expect(images[0].hidden).toBe(false);
         expect(images[1].hidden).toBe(false);
-
-        const toggle = container.querySelector('.inline-image-toggle');
-        expect(toggle).toBeTruthy();
-        expect(toggle.textContent).toContain('2 inline images shown');
-    });
-
-    test('toggle hides inline images and persists the preference', () => {
-        const iconImage = 'data:image/png;base64,icon';
-        const screenshotImage = 'data:image/png;base64,screen';
-
-        renderer.render(createMockMessage({
-            bodyContentHTML: `
-                <p>
-                    <img src="${iconImage}" alt="asset-a.png" width="84" height="67">
-                    <img src="${screenshotImage}" alt="asset-b.jpg" width="640" height="480">
-                </p>
-            `,
-            attachments: [
-                { fileName: 'asset-a.png', attachMimeTag: 'image/png', contentBase64: iconImage, pidContentId: 'cid-a' },
-                { fileName: 'asset-b.jpg', attachMimeTag: 'image/png', contentBase64: screenshotImage, pidContentId: 'cid-b' }
-            ]
-        }));
-
-        const images = container.querySelectorAll('.email-content img');
-        const toggleButton = container.querySelector('[data-action="toggle-inline-images"]');
-
-        toggleButton.click();
-
-        expect(images[0].hidden).toBe(true);
-        expect(images[1].hidden).toBe(true);
-        expect(container.querySelector('.inline-image-toggle').textContent).toContain('2 inline images hidden');
-        expect(toggleButton.textContent).toBe('Show inline images');
-        expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(false);
-    });
-
-    test('respects saved preference to hide inline images', () => {
-        window.localStorage.setItem('msgReader_showInlineImages', JSON.stringify(false));
-        const screenshotImage = 'data:image/png;base64,screen';
-
-        renderer.render(createMockMessage({
-            bodyContentHTML: `<p><img src="${screenshotImage}" alt="asset-c.png" width="220" height="140"></p>`,
-            attachments: [{ fileName: 'asset-c.png', attachMimeTag: 'image/png', contentBase64: screenshotImage, pidContentId: 'cid-c' }]
-        }));
-
-        const image = container.querySelector('.email-content img');
-        expect(image.hidden).toBe(true);
-        expect(container.querySelector('.inline-image-toggle').textContent).toContain('1 inline image hidden');
+        expect(container.querySelector('.inline-image-toggle')).toBeFalsy();
     });
 
     test('renders pin button with data attributes', () => {

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -926,7 +926,7 @@ describe('MessageContentRenderer', () => {
         expect(image.dataset.inlineImagePreviewable).toBe('true');
         expect(image.dataset.inlineImageFilename).toBe('inline-image.png');
         expect(image.getAttribute('role')).toBe('button');
-        expect(image.tabIndex).toBe(-1);
+        expect(image.tabIndex).toBe(0);
     });
 
     test('clicking inline images opens the modal preview', () => {
@@ -945,7 +945,7 @@ describe('MessageContentRenderer', () => {
         });
     });
 
-    test('hides inline images by default and shows a toggle', () => {
+    test('shows inline images by default and shows a toggle', () => {
         const iconImage = 'data:image/png;base64,icon';
         const screenshotImage = 'data:image/png;base64,screen';
 
@@ -963,15 +963,15 @@ describe('MessageContentRenderer', () => {
         }));
 
         const images = container.querySelectorAll('.email-content img');
-        expect(images[0].hidden).toBe(true);
-        expect(images[1].hidden).toBe(true);
+        expect(images[0].hidden).toBe(false);
+        expect(images[1].hidden).toBe(false);
 
         const toggle = container.querySelector('.inline-image-toggle');
         expect(toggle).toBeTruthy();
-        expect(toggle.textContent).toContain('2 inline images hidden');
+        expect(toggle.textContent).toContain('2 inline images shown');
     });
 
-    test('toggle reveals inline images and persists the preference', () => {
+    test('toggle hides inline images and persists the preference', () => {
         const iconImage = 'data:image/png;base64,icon';
         const screenshotImage = 'data:image/png;base64,screen';
 
@@ -993,15 +993,15 @@ describe('MessageContentRenderer', () => {
 
         toggleButton.click();
 
-        expect(images[0].hidden).toBe(false);
-        expect(images[1].hidden).toBe(false);
-        expect(container.querySelector('.inline-image-toggle').textContent).toContain('2 inline images shown');
-        expect(toggleButton.textContent).toBe('Hide inline images');
-        expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(true);
+        expect(images[0].hidden).toBe(true);
+        expect(images[1].hidden).toBe(true);
+        expect(container.querySelector('.inline-image-toggle').textContent).toContain('2 inline images hidden');
+        expect(toggleButton.textContent).toBe('Show inline images');
+        expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(false);
     });
 
-    test('respects saved preference to show inline images', () => {
-        window.localStorage.setItem('msgReader_showInlineImages', JSON.stringify(true));
+    test('respects saved preference to hide inline images', () => {
+        window.localStorage.setItem('msgReader_showInlineImages', JSON.stringify(false));
         const screenshotImage = 'data:image/png;base64,screen';
 
         renderer.render(createMockMessage({
@@ -1010,8 +1010,8 @@ describe('MessageContentRenderer', () => {
         }));
 
         const image = container.querySelector('.email-content img');
-        expect(image.hidden).toBe(false);
-        expect(container.querySelector('.inline-image-toggle').textContent).toContain('1 inline image shown');
+        expect(image.hidden).toBe(true);
+        expect(container.querySelector('.inline-image-toggle').textContent).toContain('1 inline image hidden');
     });
 
     test('renders pin button with data attributes', () => {

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -64,6 +64,7 @@ function setupDOM() {
                 <button id="attachmentModalZoomReset"><span id="attachmentModalZoomValue">100%</span></button>
                 <button id="attachmentModalZoomIn"></button>
             </div>
+            <a id="attachmentModalSourceLink" hidden></a>
             <span id="attachmentModalFilename"></span>
             <div id="attachmentModalContent"></div>
             <button id="attachmentModalPrev" style="display: none;"></button>
@@ -410,6 +411,7 @@ describe('AttachmentModalManager', () => {
                     <button id="attachmentModalZoomReset"><span id="attachmentModalZoomValue">100%</span></button>
                     <button id="attachmentModalZoomIn"></button>
                 </div>
+                <a id="attachmentModalSourceLink" hidden></a>
                 <span id="attachmentModalFilename"></span>
                 <div id="attachmentModalContent"></div>
                 <button id="attachmentModalPrev" style="display: none;"></button>
@@ -566,6 +568,24 @@ describe('AttachmentModalManager', () => {
             modal.renderAttachmentPreview(att);
 
             expect(modal.attachmentModalZoomControls.hidden).toBe(true);
+        });
+
+        test('shows the original link action for linked inline images', () => {
+            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            modal.setInlineImageMetadata(att.contentBase64, { linkHref: 'https://example.com/details' });
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            expect(modal.attachmentModalSourceLink.hidden).toBe(false);
+            expect(modal.attachmentModalSourceLink.href).toBe('https://example.com/details');
+        });
+
+        test('hides the original link action when no source link exists', () => {
+            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            expect(modal.attachmentModalSourceLink.hidden).toBe(true);
         });
 
         test('zooms image previews with the toolbar controls', () => {
@@ -871,6 +891,7 @@ describe('MessageContentRenderer', () => {
             isPdf: jest.fn(() => false),
             isText: jest.fn(() => false),
             isPreviewableEml: jest.fn(() => false),
+            setInlineImageMetadata: jest.fn(),
             openInlineImage: jest.fn()
         };
 
@@ -940,7 +961,28 @@ describe('MessageContentRenderer', () => {
 
         expect(mockModal.openInlineImage).toHaveBeenCalledWith({
             source: inlineImage,
-            fileName: 'inline-image.png'
+            fileName: 'inline-image.png',
+            linkHref: ''
+        });
+    });
+
+    test('captures source links for linked inline images', () => {
+        const inlineImage = 'data:image/png;base64,abc';
+        renderer.render(createMockMessage({
+            bodyContentHTML: `<p><a href="https://example.com/details"><img src="${inlineImage}" alt="inline-image"></a></p>`,
+            attachments: [{ fileName: 'inline-image.png', attachMimeTag: 'image/png', contentBase64: inlineImage, pidContentId: 'cid-1' }]
+        }));
+
+        const image = container.querySelector('.email-content img');
+        image.click();
+
+        expect(mockModal.setInlineImageMetadata).toHaveBeenCalledWith(inlineImage, {
+            linkHref: 'https://example.com/details'
+        });
+        expect(mockModal.openInlineImage).toHaveBeenCalledWith({
+            source: inlineImage,
+            fileName: 'inline-image.png',
+            linkHref: 'https://example.com/details'
         });
     });
 
@@ -1079,11 +1121,13 @@ describe('MessageContentRenderer', () => {
             expect(renderer.renderAttachments({ attachments: [{ fileName: 'a.pdf' }, { fileName: 'b.pdf' }] })).toContain('2 Attachments');
         });
 
-        test('excludes inline image attachments from attachment section', () => {
+        test('renders inline images in a separate collapsed section', () => {
             const result = renderer.renderAttachments({
                 attachments: [{ fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }]
             });
-            expect(result).toBe('');
+            expect(result).toContain('Inline image');
+            expect(result).toContain('data-inline-images-toggle');
+            expect(result).toContain('hidden');
         });
 
         test('renders previewable with preview action', () => {
@@ -1097,6 +1141,24 @@ describe('MessageContentRenderer', () => {
             const result = renderer.renderAttachments({ attachments: [{ fileName: 'archive.zip', attachMimeTag: 'application/zip', contentBase64: 'data:', contentLength: 100 }] });
             expect(result).toContain('data-action="download"');
             expect(result).not.toContain('data-action="preview"');
+        });
+
+        test('persists inline image section visibility when toggled', () => {
+            renderer.render(createMockMessage({
+                attachments: [{ fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }]
+            }));
+
+            const toggle = container.querySelector('[data-inline-images-toggle]');
+            const content = container.querySelector('[data-inline-images-content]');
+
+            expect(toggle.getAttribute('aria-expanded')).toBe('false');
+            expect(content.hidden).toBe(true);
+
+            toggle.click();
+
+            expect(toggle.getAttribute('aria-expanded')).toBe('true');
+            expect(content.hidden).toBe(false);
+            expect(JSON.parse(window.localStorage.getItem('msgReader_inlineImageAttachments'))).toBe('expanded');
         });
     });
 });

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -59,6 +59,11 @@ function setupDOM() {
             <button id="attachmentModalClose"></button>
             <a id="attachmentModalDownload"></a>
             <button id="attachmentModalBack" style="display: none;"></button>
+            <div id="attachmentModalZoomControls" hidden>
+                <button id="attachmentModalZoomOut"></button>
+                <button id="attachmentModalZoomReset"><span id="attachmentModalZoomValue">100%</span></button>
+                <button id="attachmentModalZoomIn"></button>
+            </div>
             <span id="attachmentModalFilename"></span>
             <div id="attachmentModalContent"></div>
             <button id="attachmentModalPrev" style="display: none;"></button>
@@ -391,6 +396,7 @@ describe('ToastManager', () => {
 
 describe('AttachmentModalManager', () => {
     let modal;
+    let loadImageDimensions;
 
     beforeEach(() => {
         document.body.innerHTML = `
@@ -398,6 +404,12 @@ describe('AttachmentModalManager', () => {
                 <div class="attachment-modal-backdrop"></div>
                 <button id="attachmentModalClose"></button>
                 <a id="attachmentModalDownload"></a>
+                <button id="attachmentModalBack" style="display: none;"></button>
+                <div id="attachmentModalZoomControls" hidden>
+                    <button id="attachmentModalZoomOut"></button>
+                    <button id="attachmentModalZoomReset"><span id="attachmentModalZoomValue">100%</span></button>
+                    <button id="attachmentModalZoomIn"></button>
+                </div>
                 <span id="attachmentModalFilename"></span>
                 <div id="attachmentModalContent"></div>
                 <button id="attachmentModalPrev" style="display: none;"></button>
@@ -406,6 +418,11 @@ describe('AttachmentModalManager', () => {
         `;
         isTauri.mockReturnValue(false);
         modal = new AttachmentModalManager(jest.fn());
+        loadImageDimensions = (image, { naturalWidth = 1200, naturalHeight = 600 } = {}) => {
+            Object.defineProperty(image, 'naturalWidth', { configurable: true, value: naturalWidth });
+            Object.defineProperty(image, 'naturalHeight', { configurable: true, value: naturalHeight });
+            image.dispatchEvent(new Event('load'));
+        };
     });
 
     afterEach(() => {
@@ -528,6 +545,80 @@ describe('AttachmentModalManager', () => {
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             expect(modal.attachmentModalContent.querySelector('img')).toBeTruthy();
+        });
+
+        test('shows zoom controls for image previews', () => {
+            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            const image = modal.attachmentModalContent.querySelector('img');
+            loadImageDimensions(image);
+
+            expect(modal.attachmentModalZoomControls.hidden).toBe(false);
+            expect(modal.attachmentModalZoomValue.textContent).toBe('100%');
+            expect(modal.attachmentModalZoomOut.disabled).toBe(true);
+        });
+
+        test('hides zoom controls for non-image previews', () => {
+            const att = { fileName: 'test.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:application/pdf;base64,abc' };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            expect(modal.attachmentModalZoomControls.hidden).toBe(true);
+        });
+
+        test('zooms image previews with the toolbar controls', () => {
+            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            const image = modal.attachmentModalContent.querySelector('img');
+            loadImageDimensions(image);
+
+            modal.attachmentModalZoomIn.click();
+
+            expect(modal.imageZoomLevel).toBe(1.25);
+            expect(modal.attachmentModalZoomValue.textContent).toBe('125%');
+            expect(image.style.width).toBe('1200px');
+
+            modal.attachmentModalZoomReset.click();
+
+            expect(modal.imageZoomLevel).toBe(1);
+            expect(modal.attachmentModalZoomValue.textContent).toBe('100%');
+            expect(image.style.width).toBe('960px');
+        });
+
+        test('supports Ctrl+wheel zoom for image previews', () => {
+            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+
+            const image = modal.attachmentModalContent.querySelector('img');
+            loadImageDimensions(image);
+
+            const preventDefault = jest.fn();
+            modal.handleModalWheel({ ctrlKey: true, metaKey: false, deltaY: -120, preventDefault });
+
+            expect(preventDefault).toHaveBeenCalled();
+            expect(modal.imageZoomLevel).toBe(1.25);
+        });
+
+        test('resets image zoom when switching previews', () => {
+            const first = { fileName: 'first.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,first' };
+            const second = { fileName: 'second.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,second' };
+            modal.setAttachments([first, second]);
+
+            modal.renderAttachmentPreview(first);
+            loadImageDimensions(modal.attachmentModalContent.querySelector('img'));
+            modal.attachmentModalZoomIn.click();
+
+            modal.renderAttachmentPreview(second);
+            loadImageDimensions(modal.attachmentModalContent.querySelector('img'), { naturalWidth: 800, naturalHeight: 800 });
+
+            expect(modal.imageZoomLevel).toBe(1);
+            expect(modal.attachmentModalZoomValue.textContent).toBe('100%');
+            expect(modal.attachmentModalZoomOut.disabled).toBe(true);
         });
 
         test('creates object for PDFs', () => {

--- a/tests/integration/file-flow.test.js
+++ b/tests/integration/file-flow.test.js
@@ -399,6 +399,47 @@ describe('File Opening Flow Integration', () => {
             expect(toggle.getAttribute('aria-expanded')).toBe('true');
             expect(content.hidden).toBe(false);
         });
+
+        it('should navigate from regular attachments into inline images when the inline section is expanded', async () => {
+            const regularImage = 'data:image/png;base64,regular';
+            const inlineImage = 'data:image/png;base64,inline';
+            const mockMessage = createMockParsedMessage({
+                bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image.png"></p>`,
+                attachments: [
+                    {
+                        fileName: 'regular-image.png',
+                        attachMimeTag: 'image/png',
+                        contentLength: 2048,
+                        contentBase64: regularImage
+                    },
+                    {
+                        fileName: 'inline-image.png',
+                        attachMimeTag: 'image/png',
+                        contentLength: 1024,
+                        contentBase64: inlineImage,
+                        pidContentId: 'inline-image-1',
+                        contentId: 'inline-image-1'
+                    }
+                ]
+            });
+            mockParsers.extractMsg.mockReturnValue(mockMessage);
+
+            fileHandler.handleFiles([createMockFile('nav-inline.msg', 'mock')]);
+            await waitForDOMUpdate(100);
+
+            domElements.messageViewer.querySelector('[data-inline-images-toggle]').click();
+            await waitForDOMUpdate(0);
+
+            domElements.messageViewer.querySelector('[data-action="preview"]').click();
+            await waitForDOMUpdate(0);
+            expect(document.getElementById('attachmentModalFilename').textContent).toContain('regular-image.png');
+
+            document.getElementById('attachmentModalNext').click();
+            await waitForDOMUpdate(0);
+
+            expect(document.getElementById('attachmentModalFilename').textContent).toContain('inline-image.png');
+            expect(document.querySelector('#attachmentModalContent img').src).toContain(inlineImage);
+        });
     });
 
     describe('Unsupported file types', () => {

--- a/tests/integration/file-flow.test.js
+++ b/tests/integration/file-flow.test.js
@@ -269,6 +269,7 @@ describe('File Opening Flow Integration', () => {
             expect(domElements.attachmentModal.classList.contains('active')).toBe(true);
             expect(document.getElementById('attachmentModalFilename').textContent).toContain('inline-image.png');
             expect(document.querySelector('#attachmentModalContent img').src).toContain(inlineImage);
+            expect(document.getElementById('attachmentModalZoomControls').hidden).toBe(false);
         });
 
         it('should hide inline images by default behind a toggle', async () => {

--- a/tests/integration/file-flow.test.js
+++ b/tests/integration/file-flow.test.js
@@ -236,7 +236,6 @@ describe('File Opening Flow Integration', () => {
 
         it('should open inline images in the attachment modal', async () => {
             // Arrange
-            window.localStorage.setItem('msgReader_showInlineImages', JSON.stringify(true));
             const inlineImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE';
             const mockMessage = createMockMessageWithInlineImages({
                 bodyContentHTML: `<p>Here is an image: <img src="${inlineImage}" alt="inline-image.png"></p>`,
@@ -272,7 +271,7 @@ describe('File Opening Flow Integration', () => {
             expect(document.getElementById('attachmentModalZoomControls').hidden).toBe(false);
         });
 
-        it('should show inline images by default and allow hiding them behind a toggle', async () => {
+        it('should always show inline images in the message body', async () => {
             // Arrange
             const iconImage = 'data:image/png;base64,icon';
             const screenshotImage = 'data:image/png;base64,screen';
@@ -311,18 +310,11 @@ describe('File Opening Flow Integration', () => {
             await waitForDOMUpdate(100);
 
             const images = domElements.messageViewer.querySelectorAll('.email-content img');
-            const toggleButton = domElements.messageViewer.querySelector('[data-action="toggle-inline-images"]');
 
             // Assert
             expect(images[0].hidden).toBe(false);
             expect(images[1].hidden).toBe(false);
-            expect(toggleButton).not.toBeNull();
-
-            toggleButton.click();
-
-            expect(images[0].hidden).toBe(true);
-            expect(images[1].hidden).toBe(true);
-            expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(false);
+            expect(domElements.messageViewer.querySelector('.inline-image-toggle')).toBeNull();
         });
 
         it('should not render inline images in the attachment section', async () => {

--- a/tests/integration/file-flow.test.js
+++ b/tests/integration/file-flow.test.js
@@ -271,6 +271,36 @@ describe('File Opening Flow Integration', () => {
             expect(document.getElementById('attachmentModalZoomControls').hidden).toBe(false);
         });
 
+        it('should expose the original link in the modal for linked inline images', async () => {
+            const inlineImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE';
+            const mockMessage = createMockMessageWithInlineImages({
+                bodyContentHTML: `<p><a href="https://example.com/details"><img src="${inlineImage}" alt="inline-image.png"></a></p>`,
+                attachments: [
+                    {
+                        fileName: 'inline-image.png',
+                        attachMimeTag: 'image/png',
+                        contentLength: 1024,
+                        contentBase64: inlineImage,
+                        pidContentId: 'inline-image-1',
+                        contentId: 'inline-image-1'
+                    }
+                ]
+            });
+            mockParsers.extractMsg.mockReturnValue(mockMessage);
+
+            const msgFile = createMockFile('inline-image-link.msg', 'mock content');
+
+            fileHandler.handleFiles([msgFile]);
+            await waitForDOMUpdate(100);
+
+            domElements.messageViewer.querySelector('.email-content img').click();
+            await waitForDOMUpdate(0);
+
+            const sourceLink = document.getElementById('attachmentModalSourceLink');
+            expect(sourceLink.hidden).toBe(false);
+            expect(sourceLink.href).toBe('https://example.com/details');
+        });
+
         it('should always show inline images in the message body', async () => {
             // Arrange
             const iconImage = 'data:image/png;base64,icon';
@@ -317,7 +347,7 @@ describe('File Opening Flow Integration', () => {
             expect(domElements.messageViewer.querySelector('.inline-image-toggle')).toBeNull();
         });
 
-        it('should not render inline images in the attachment section', async () => {
+        it('should render inline images in a separate collapsed attachment section', async () => {
             // Arrange
             const mockMessage = createMockMessageWithInlineImages();
             mockParsers.extractMsg.mockReturnValue(mockMessage);
@@ -329,8 +359,45 @@ describe('File Opening Flow Integration', () => {
             await waitForDOMUpdate(100);
 
             // Assert
-            expect(domElements.messageViewer.innerHTML).not.toContain('Attachment');
-            expect(domElements.messageViewer.innerHTML).not.toContain('inline-image.png');
+            expect(domElements.messageViewer.innerHTML).toContain('Inline image');
+            expect(domElements.messageViewer.innerHTML).toContain('Show');
+            expect(domElements.messageViewer.querySelector('[data-inline-images-content]').hidden).toBe(true);
+        });
+
+        it('should persist inline image section visibility across messages', async () => {
+            const firstMessage = createMockMessageWithInlineImages();
+            const secondMessage = createMockMessageWithInlineImages({
+                subject: 'Second message',
+                attachments: [
+                    {
+                        fileName: 'inline-image-2.png',
+                        attachMimeTag: 'image/png',
+                        contentLength: 2048,
+                        contentBase64: 'data:image/png;base64,second',
+                        pidContentId: 'inline-image-2',
+                        contentId: 'inline-image-2'
+                    }
+                ],
+                bodyContentHTML: '<p><img src="data:image/png;base64,second" alt="inline-image-2.png"></p>'
+            });
+            mockParsers.extractMsg
+                .mockReturnValueOnce(firstMessage)
+                .mockReturnValueOnce(secondMessage);
+
+            fileHandler.handleFiles([createMockFile('first.msg', 'mock')]);
+            await waitForDOMUpdate(100);
+
+            domElements.messageViewer.querySelector('[data-inline-images-toggle]').click();
+            expect(JSON.parse(window.localStorage.getItem('msgReader_inlineImageAttachments'))).toBe('expanded');
+
+            fileHandler.handleFiles([createMockFile('second.msg', 'mock')]);
+            await waitForDOMUpdate(100);
+
+            const content = domElements.messageViewer.querySelector('[data-inline-images-content]');
+            const toggle = domElements.messageViewer.querySelector('[data-inline-images-toggle]');
+
+            expect(toggle.getAttribute('aria-expanded')).toBe('true');
+            expect(content.hidden).toBe(false);
         });
     });
 

--- a/tests/integration/file-flow.test.js
+++ b/tests/integration/file-flow.test.js
@@ -272,7 +272,7 @@ describe('File Opening Flow Integration', () => {
             expect(document.getElementById('attachmentModalZoomControls').hidden).toBe(false);
         });
 
-        it('should hide inline images by default behind a toggle', async () => {
+        it('should show inline images by default and allow hiding them behind a toggle', async () => {
             // Arrange
             const iconImage = 'data:image/png;base64,icon';
             const screenshotImage = 'data:image/png;base64,screen';
@@ -314,15 +314,15 @@ describe('File Opening Flow Integration', () => {
             const toggleButton = domElements.messageViewer.querySelector('[data-action="toggle-inline-images"]');
 
             // Assert
-            expect(images[0].hidden).toBe(true);
-            expect(images[1].hidden).toBe(true);
+            expect(images[0].hidden).toBe(false);
+            expect(images[1].hidden).toBe(false);
             expect(toggleButton).not.toBeNull();
 
             toggleButton.click();
 
-            expect(images[0].hidden).toBe(false);
-            expect(images[1].hidden).toBe(false);
-            expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(true);
+            expect(images[0].hidden).toBe(true);
+            expect(images[1].hidden).toBe(true);
+            expect(JSON.parse(window.localStorage.getItem('msgReader_showInlineImages'))).toBe(false);
         });
 
         it('should not render inline images in the attachment section', async () => {

--- a/tests/integration/test-helpers.js
+++ b/tests/integration/test-helpers.js
@@ -138,8 +138,16 @@ export function setupFullDOM() {
             <div class="attachment-modal-backdrop"></div>
             <div class="attachment-modal-container">
                 <div class="attachment-modal-header">
+                    <button id="attachmentModalBack" class="attachment-modal-back" title="Back" style="display: none;"></button>
                     <span id="attachmentModalFilename" class="attachment-modal-filename" role="heading" aria-level="2"></span>
                     <div class="attachment-modal-actions">
+                        <div id="attachmentModalZoomControls" class="attachment-modal-zoom-controls" hidden>
+                            <button id="attachmentModalZoomOut" type="button" class="attachment-modal-zoom-button" title="Zoom out"></button>
+                            <button id="attachmentModalZoomReset" type="button" class="attachment-modal-zoom-button attachment-modal-zoom-reset" title="Reset zoom">
+                                <span id="attachmentModalZoomValue" class="attachment-modal-zoom-value">100%</span>
+                            </button>
+                            <button id="attachmentModalZoomIn" type="button" class="attachment-modal-zoom-button" title="Zoom in"></button>
+                        </div>
                         <a id="attachmentModalDownload" href="#" download="" class="attachment-modal-download" title="Download"></a>
                         <button id="attachmentModalClose" class="attachment-modal-close" title="Close"></button>
                     </div>

--- a/tests/integration/test-helpers.js
+++ b/tests/integration/test-helpers.js
@@ -148,6 +148,7 @@ export function setupFullDOM() {
                             </button>
                             <button id="attachmentModalZoomIn" type="button" class="attachment-modal-zoom-button" title="Zoom in"></button>
                         </div>
+                        <a id="attachmentModalSourceLink" href="#" class="attachment-modal-source-link" title="Open linked target" hidden>Open link</a>
                         <a id="attachmentModalDownload" href="#" download="" class="attachment-modal-download" title="Download"></a>
                         <button id="attachmentModalClose" class="attachment-modal-close" title="Close"></button>
                     </div>


### PR DESCRIPTION
## Summary
- give the attachment preview modal a consistent viewer size so inline images open in a larger lightbox
- add image zoom controls with zoom in, zoom out, reset, and Ctrl/Cmd+wheel support inside the preview modal
- reset zoom state when switching attachments and add unit/integration coverage for the new preview behavior

## Testing
- npm test -- --runInBand
- npm run lint
- npm run build

Closes #41.