### PR TITLE
fix: handle charset decoding for MSG and EML

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
     "useTabs": false,
     "trailingComma": "none",
     "bracketSpacing": true,
-    "arrowParens": "(always)",
+    "arrowParens": "always",
     "printWidth": 100,
     "endOfLine": "lf"
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -8,11 +8,39 @@
  * Used for decoding email content with specific encodings
  */
 export const CHARSET_CODES = {
-    936: 'gbk',       // Simplified Chinese (GBK)
-    950: 'big5',      // Traditional Chinese (Big5)
+    437: 'cp437', // OEM United States
+    850: 'cp850', // OEM Western Europe
+    874: 'windows-874', // Thai
+    1200: 'utf-16le', // Unicode UTF-16 Little Endian
+    1201: 'utf-16be', // Unicode UTF-16 Big Endian
+    1250: 'windows-1250', // Central European
+    1251: 'windows-1251', // Cyrillic
+    1252: 'windows-1252', // Western European
+    1253: 'windows-1253', // Greek
+    1254: 'windows-1254', // Turkish
+    1255: 'windows-1255', // Hebrew
+    1256: 'windows-1256', // Arabic
+    1257: 'windows-1257', // Baltic
+    1258: 'windows-1258', // Vietnamese
+    20127: 'ascii', // US-ASCII
+    28591: 'iso-8859-1',
+    28592: 'iso-8859-2',
+    28593: 'iso-8859-3',
+    28594: 'iso-8859-4',
+    28595: 'iso-8859-5',
+    28596: 'iso-8859-6',
+    28597: 'iso-8859-7',
+    28598: 'iso-8859-8',
+    28599: 'iso-8859-9',
+    28605: 'iso-8859-15',
+    936: 'gbk', // Simplified Chinese (GBK)
+    950: 'big5', // Traditional Chinese (Big5)
     932: 'shift_jis', // Japanese (Shift_JIS)
-    949: 'cp949',     // Korean (CP949/EUC-KR)
-    928: 'gb2312'     // Simplified Chinese (GB2312)
+    949: 'cp949', // Korean (CP949/EUC-KR)
+    928: 'gb2312', // Simplified Chinese (GB2312)
+    51949: 'euc-kr',
+    54936: 'gb18030',
+    65001: 'utf-8'
 };
 
 /**
@@ -52,7 +80,8 @@ export const PDF_MIME_TYPE = 'application/pdf';
  * Placeholder SVG for missing/broken images
  * Displays "Image not available" text
  */
-export const PLACEHOLDER_IMAGE_SVG = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iNTAiPjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iNTAiIGZpbGw9IiNlZWUiLz48dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9InNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTkiPkltYWdlIG5vdCBhdmFpbGFibGU8L3RleHQ+PC9zdmc+';
+export const PLACEHOLDER_IMAGE_SVG =
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iNTAiPjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iNTAiIGZpbGw9IiNlZWUiLz48dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9InNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTkiPkltYWdlIG5vdCBhdmFpbGFibGU8L3RleHQ+PC9zdmc+';
 
 /**
  * File types considered safe for download
@@ -60,7 +89,12 @@ export const PLACEHOLDER_IMAGE_SVG = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0i
  */
 export const SAFE_DOWNLOAD_TYPES = new Set([
     // Images
-    'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml', 'image/bmp',
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'image/svg+xml',
+    'image/bmp',
     // Documents
     'application/pdf',
     'application/msword',
@@ -70,11 +104,17 @@ export const SAFE_DOWNLOAD_TYPES = new Set([
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     // Text
-    'text/plain', 'text/html', 'text/css', 'text/csv',
+    'text/plain',
+    'text/html',
+    'text/css',
+    'text/csv',
     // Data
-    'application/json', 'application/xml',
+    'application/json',
+    'application/xml',
     // Archives
-    'application/zip', 'application/x-rar-compressed', 'application/gzip'
+    'application/zip',
+    'application/x-rar-compressed',
+    'application/gzip'
 ]);
 
 /**
@@ -82,10 +122,33 @@ export const SAFE_DOWNLOAD_TYPES = new Set([
  * These should trigger a warning before download
  */
 export const DANGEROUS_EXTENSIONS = new Set([
-    'exe', 'bat', 'cmd', 'com', 'msi', 'scr', 'pif',
-    'vbs', 'vbe', 'js', 'jse', 'ws', 'wsf', 'wsc', 'wsh',
-    'ps1', 'ps1xml', 'ps2', 'ps2xml', 'psc1', 'psc2',
-    'jar', 'hta', 'cpl', 'msc', 'inf', 'reg'
+    'exe',
+    'bat',
+    'cmd',
+    'com',
+    'msi',
+    'scr',
+    'pif',
+    'vbs',
+    'vbe',
+    'js',
+    'jse',
+    'ws',
+    'wsf',
+    'wsc',
+    'wsh',
+    'ps1',
+    'ps1xml',
+    'ps2',
+    'ps2xml',
+    'psc1',
+    'psc2',
+    'jar',
+    'hta',
+    'cpl',
+    'msc',
+    'inf',
+    'reg'
 ]);
 
 /**

--- a/src/js/encoding.js
+++ b/src/js/encoding.js
@@ -1,0 +1,231 @@
+import iconvLite from 'iconv-lite';
+import { Buffer } from 'buffer';
+
+import { DEFAULT_CHARSET } from './constants.js';
+
+const FALLBACK_CHARSET = 'windows-1252';
+
+const CHARSET_ALIASES = {
+    'ansi_x3.4-1968': 'ascii',
+    cp1250: 'windows-1250',
+    cp1251: 'windows-1251',
+    cp1252: 'windows-1252',
+    cp1253: 'windows-1253',
+    cp1254: 'windows-1254',
+    cp1255: 'windows-1255',
+    cp1256: 'windows-1256',
+    cp1257: 'windows-1257',
+    cp1258: 'windows-1258',
+    latin1: 'iso-8859-1',
+    'latin-1': 'iso-8859-1',
+    unicode: 'utf-16le',
+    utf8: 'utf-8',
+    'us-ascii': 'ascii',
+    win1252: 'windows-1252'
+};
+
+function toBuffer(bytes) {
+    if (!bytes) return Buffer.from([]);
+    return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+}
+
+function countReplacementChars(value) {
+    return (value.match(/\ufffd/g) || []).length;
+}
+
+function isUtf8Charset(charset) {
+    return charset === 'utf-8' || charset === 'utf8';
+}
+
+function isValidUtf8(buffer) {
+    let expectedContinuationBytes = 0;
+    let codePoint = 0;
+    let minCodePoint = 0;
+
+    for (const byte of buffer) {
+        if (expectedContinuationBytes > 0) {
+            if ((byte & 0xc0) !== 0x80) return false;
+            codePoint = (codePoint << 6) | (byte & 0x3f);
+            expectedContinuationBytes -= 1;
+
+            if (expectedContinuationBytes === 0) {
+                if (codePoint < minCodePoint) return false;
+                if (codePoint > 0x10ffff) return false;
+                if (codePoint >= 0xd800 && codePoint <= 0xdfff) return false;
+            }
+            continue;
+        }
+
+        if (byte <= 0x7f) {
+            continue;
+        } else if (byte >= 0xc2 && byte <= 0xdf) {
+            expectedContinuationBytes = 1;
+            codePoint = byte & 0x1f;
+            minCodePoint = 0x80;
+        } else if (byte >= 0xe0 && byte <= 0xef) {
+            expectedContinuationBytes = 2;
+            codePoint = byte & 0x0f;
+            minCodePoint = 0x800;
+        } else if (byte >= 0xf0 && byte <= 0xf4) {
+            expectedContinuationBytes = 3;
+            codePoint = byte & 0x07;
+            minCodePoint = 0x10000;
+        } else {
+            return false;
+        }
+    }
+
+    return expectedContinuationBytes === 0;
+}
+
+export function normalizeCharset(charset = DEFAULT_CHARSET) {
+    const normalized = String(charset || DEFAULT_CHARSET)
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .toLowerCase();
+
+    return CHARSET_ALIASES[normalized] || normalized || DEFAULT_CHARSET;
+}
+
+function resolveSupportedCharset(charset) {
+    const normalizedCharset = normalizeCharset(charset);
+
+    return iconvLite.encodingExists(normalizedCharset) ? normalizedCharset : DEFAULT_CHARSET;
+}
+
+function decodeWithCharset(buffer, charset) {
+    return iconvLite.decode(buffer, resolveSupportedCharset(charset));
+}
+
+export function decodeBytes(bytes, charset = DEFAULT_CHARSET, options = {}) {
+    const buffer = toBuffer(bytes);
+    const requestedCharset = normalizeCharset(charset);
+    const effectiveCharset = resolveSupportedCharset(requestedCharset);
+    const decoded = decodeWithCharset(buffer, requestedCharset);
+    const fallbackCharset = normalizeCharset(options.fallbackCharset || FALLBACK_CHARSET);
+
+    let result = decoded;
+    if (fallbackCharset && isUtf8Charset(effectiveCharset) && !isValidUtf8(buffer)) {
+        const fallbackDecoded = decodeWithCharset(buffer, fallbackCharset);
+        if (countReplacementChars(fallbackDecoded) <= countReplacementChars(decoded)) {
+            result = fallbackDecoded;
+        }
+    }
+
+    return options.trim ? result.trim() : result;
+}
+
+export function binaryStringToBuffer(value = '') {
+    return Buffer.from(value || '', 'binary');
+}
+
+export function binaryStringToBase64(value = '') {
+    return binaryStringToBuffer(value).toString('base64');
+}
+
+export function decodeBinaryString(value = '', charset = DEFAULT_CHARSET, options = {}) {
+    return decodeBytes(binaryStringToBuffer(value), charset, options);
+}
+
+export function textToBase64(value = '') {
+    return Buffer.from(value || '', 'utf-8').toString('base64');
+}
+
+export function base64ToBuffer(value = '') {
+    return Buffer.from((value || '').replace(/\s/g, ''), 'base64');
+}
+
+export function base64ToArrayBuffer(value = '') {
+    const buffer = base64ToBuffer(value);
+    return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+export function decodeBase64Text(value = '', charset = DEFAULT_CHARSET, options = {}) {
+    return decodeBytes(base64ToBuffer(value), charset, options);
+}
+
+export function getDataUrlBase64(dataUrl = '') {
+    return dataUrl.split(',')[1] || '';
+}
+
+export function getDataUrlCharset(dataUrl = '', fallback = DEFAULT_CHARSET) {
+    const metadata = dataUrl.split(',')[0] || '';
+    const match = metadata.match(/(?:^|;)charset=([^;,]+)/i);
+    return match ? normalizeCharset(match[1]) : fallback;
+}
+
+export function decodeDataUrlText(dataUrl = '', fallbackCharset = DEFAULT_CHARSET, options = {}) {
+    return decodeBase64Text(
+        getDataUrlBase64(dataUrl),
+        getDataUrlCharset(dataUrl, fallbackCharset),
+        options
+    );
+}
+
+export function dataUrlToArrayBuffer(dataUrl = '') {
+    return base64ToArrayBuffer(getDataUrlBase64(dataUrl));
+}
+
+export function quotedPrintableToBuffer(value = '', options = {}) {
+    const input = options.mimeWord ? value.replace(/_/g, ' ') : value.replace(/=\r?\n/g, '');
+    const bytes = [];
+
+    for (let i = 0; i < input.length; i += 1) {
+        const char = input[i];
+        const hex = input.slice(i + 1, i + 3);
+
+        if (char === '=' && /^[0-9A-F]{2}$/i.test(hex)) {
+            bytes.push(parseInt(hex, 16));
+            i += 2;
+        } else {
+            bytes.push(input.charCodeAt(i) & 0xff);
+        }
+    }
+
+    return Buffer.from(bytes);
+}
+
+export function decodeQuotedPrintable(value = '', charset = DEFAULT_CHARSET, options = {}) {
+    return decodeBytes(quotedPrintableToBuffer(value, options), charset, options);
+}
+
+export function percentEncodedToBuffer(value = '') {
+    const bytes = [];
+
+    for (let i = 0; i < value.length; i += 1) {
+        const char = value[i];
+        const hex = value.slice(i + 1, i + 3);
+
+        if (char === '%' && /^[0-9A-F]{2}$/i.test(hex)) {
+            bytes.push(parseInt(hex, 16));
+            i += 2;
+        } else {
+            bytes.push(value.charCodeAt(i) & 0xff);
+        }
+    }
+
+    return Buffer.from(bytes);
+}
+
+export function decodePercentEncodedText(value = '', charset = DEFAULT_CHARSET, options = {}) {
+    return decodeBytes(percentEncodedToBuffer(value), charset, options);
+}
+
+export function decodeMimeWords(value = '') {
+    if (!value) return '';
+
+    return value
+        .replace(/(=\?[^?]+\?[BQbq]\?[^?]*\?=)\s+(?==\?[^?]+\?[BQbq]\?)/g, '$1')
+        .replace(/=\?([^?]+)\?([BQbq])\?([^?]*)\?=/g, (match, charset, encoding, text) => {
+            try {
+                const bytes =
+                    encoding.toUpperCase() === 'B'
+                        ? base64ToBuffer(text)
+                        : quotedPrintableToBuffer(text, { mimeWord: true });
+                return decodeBytes(bytes, charset);
+            } catch (error) {
+                console.error('Error decoding MIME word:', error);
+                return match;
+            }
+        });
+}

--- a/src/js/messageExport.js
+++ b/src/js/messageExport.js
@@ -1,4 +1,5 @@
 import { escapeHTML } from './sanitizer.js';
+import { textToBase64 } from './encoding.js';
 
 function stripExtension(fileName) {
     if (!fileName) return '';
@@ -8,7 +9,7 @@ function stripExtension(fileName) {
 function sanitizeFileComponent(value, fallback = 'message') {
     const invalidChars = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*']);
     const cleaned = Array.from(value || fallback)
-        .map(char => {
+        .map((char) => {
             if (invalidChars.has(char)) return '_';
             if (char.charCodeAt(0) < 32) return '_';
             return char;
@@ -45,21 +46,14 @@ function formatAddress(name, email) {
 }
 
 function wrapBase64(base64) {
-    return (base64 || '').replace(/\s+/g, '').replace(/.{1,76}/g, '$&\r\n').trim();
+    return (base64 || '')
+        .replace(/\s+/g, '')
+        .replace(/.{1,76}/g, '$&\r\n')
+        .trim();
 }
 
 function encodeTextAsBase64(text) {
-    if (!text) return '';
-
-    if (typeof btoa === 'function') {
-        return btoa(unescape(encodeURIComponent(text)));
-    }
-
-    if (typeof Buffer !== 'undefined') {
-        return Buffer.from(text, 'utf-8').toString('base64');
-    }
-
-    throw new Error('No base64 encoder available');
+    return textToBase64(text);
 }
 
 function getAttachmentBase64(attachment) {
@@ -71,7 +65,10 @@ function getAttachmentContentId(attachment, index) {
     const normalized = rawContentId.replace(/[<>]/g, '').trim();
     if (normalized) return normalized;
 
-    const fileName = sanitizeFileComponent(stripExtension(attachment?.fileName || `inline_${index}`), `inline_${index}`);
+    const fileName = sanitizeFileComponent(
+        stripExtension(attachment?.fileName || `inline_${index}`),
+        `inline_${index}`
+    );
     return `${fileName}@msgreader.local`;
 }
 
@@ -80,7 +77,9 @@ function partitionAttachments(bodyHtml, attachments = []) {
     const regularAttachments = [];
 
     attachments.forEach((attachment, index) => {
-        const isInline = Boolean(bodyHtml && attachment?.contentBase64 && bodyHtml.includes(attachment.contentBase64));
+        const isInline = Boolean(
+            bodyHtml && attachment?.contentBase64 && bodyHtml.includes(attachment.contentBase64)
+        );
         const withContentId = {
             ...attachment,
             exportContentId: getAttachmentContentId(attachment, index)
@@ -99,9 +98,11 @@ function partitionAttachments(bodyHtml, attachments = []) {
 function replaceInlineDataUrlsWithCid(bodyHtml, inlineAttachments) {
     let rewrittenHtml = bodyHtml;
 
-    inlineAttachments.forEach(attachment => {
+    inlineAttachments.forEach((attachment) => {
         if (!attachment.contentBase64) return;
-        rewrittenHtml = rewrittenHtml.split(attachment.contentBase64).join(`cid:${attachment.exportContentId}`);
+        rewrittenHtml = rewrittenHtml
+            .split(attachment.contentBase64)
+            .join(`cid:${attachment.exportContentId}`);
     });
 
     return rewrittenHtml;
@@ -117,12 +118,8 @@ function createPlainTextFallback(message) {
 
     if (typeof document !== 'undefined') {
         const container = document.createElement('div');
-        container.innerHTML = body
-            .replace(/<br\s*\/?>/gi, '\n')
-            .replace(/<\/p>/gi, '\n\n');
-        return (container.textContent || '')
-            .replace(/\n{3,}/g, '\n\n')
-            .trim();
+        container.innerHTML = body.replace(/<br\s*\/?>/gi, '\n').replace(/<\/p>/gi, '\n\n');
+        return (container.textContent || '').replace(/\n{3,}/g, '\n\n').trim();
     }
 
     return body
@@ -145,18 +142,26 @@ function getRawHeader(message, name) {
 
 function formatAddressList(recipients = []) {
     return recipients
-        .map(recipient => formatAddress(
-            recipient.name || recipient.smtpAddress || recipient.email || '',
-            recipient.smtpAddress || recipient.email || ''
-        ))
+        .map((recipient) =>
+            formatAddress(
+                recipient.name || recipient.smtpAddress || recipient.email || '',
+                recipient.smtpAddress || recipient.email || ''
+            )
+        )
         .filter(Boolean)
         .join(', ');
 }
 
 function buildTopLevelHeaders(message) {
-    const toRecipients = (message?.recipients || []).filter(recipient => recipient.recipType === 'to');
-    const ccRecipients = (message?.recipients || []).filter(recipient => recipient.recipType === 'cc');
-    const bccRecipients = (message?.recipients || []).filter(recipient => recipient.recipType === 'bcc');
+    const toRecipients = (message?.recipients || []).filter(
+        (recipient) => recipient.recipType === 'to'
+    );
+    const ccRecipients = (message?.recipients || []).filter(
+        (recipient) => recipient.recipType === 'cc'
+    );
+    const bccRecipients = (message?.recipients || []).filter(
+        (recipient) => recipient.recipType === 'bcc'
+    );
     const optionalHeaders = [
         ['Reply-To', getRawHeader(message, 'reply-to')],
         ['Message-ID', getRawHeader(message, 'message-id') || message?.messageId || ''],
@@ -171,11 +176,15 @@ function buildTopLevelHeaders(message) {
     ];
 
     return [
-        ['From', getRawHeader(message, 'from') || formatAddress(message?.senderName || '', message?.senderEmail || '')],
+        [
+            'From',
+            getRawHeader(message, 'from') ||
+                formatAddress(message?.senderName || '', message?.senderEmail || '')
+        ],
         ['To', getRawHeader(message, 'to') || formatAddressList(toRecipients)],
         ['Cc', getRawHeader(message, 'cc') || formatAddressList(ccRecipients)],
         ['Bcc', getRawHeader(message, 'bcc') || formatAddressList(bccRecipients)],
-        ['Subject', getRawHeader(message, 'subject') || (message?.subject || '')],
+        ['Subject', getRawHeader(message, 'subject') || message?.subject || ''],
         ['Date', getRawHeader(message, 'date') || formatTimestamp(message?.messageDeliveryTime)],
         ...optionalHeaders
     ]
@@ -194,9 +203,7 @@ export function getExportFileName(message, format) {
 }
 
 export function getOriginalMessageMimeType(message) {
-    return message?._fileType === 'eml'
-        ? 'message/rfc822'
-        : 'application/vnd.ms-outlook';
+    return message?._fileType === 'eml' ? 'message/rfc822' : 'application/vnd.ms-outlook';
 }
 
 export function messageToEml(message) {
@@ -205,7 +212,10 @@ export function messageToEml(message) {
     const boundaryAlt = `----=_msgReader_alt_${Math.random().toString(16).slice(2)}`;
     const bodyText = createPlainTextFallback(message);
     const originalHtml = message?.bodyContentHTML || `<pre>${escapeHTML(bodyText)}</pre>`;
-    const { inlineAttachments, regularAttachments } = partitionAttachments(originalHtml, message?.attachments || []);
+    const { inlineAttachments, regularAttachments } = partitionAttachments(
+        originalHtml,
+        message?.attachments || []
+    );
     const bodyHtml = replaceInlineDataUrlsWithCid(originalHtml, inlineAttachments);
 
     const headers = [
@@ -214,8 +224,8 @@ export function messageToEml(message) {
         regularAttachments.length > 0
             ? `Content-Type: multipart/mixed; boundary="${boundaryMixed}"`
             : inlineAttachments.length > 0
-                ? `Content-Type: multipart/related; boundary="${boundaryRelated}"`
-            : `Content-Type: multipart/alternative; boundary="${boundaryAlt}"`
+              ? `Content-Type: multipart/related; boundary="${boundaryRelated}"`
+              : `Content-Type: multipart/alternative; boundary="${boundaryAlt}"`
     ].filter(Boolean);
 
     const alternativeParts = [
@@ -235,7 +245,7 @@ export function messageToEml(message) {
         ''
     ];
 
-    const relatedParts = inlineAttachments.map(attachment => {
+    const relatedParts = inlineAttachments.map((attachment) => {
         const fileName = sanitizeFileComponent(attachment.fileName || 'inline');
         const mimeType = attachment.attachMimeTag || 'application/octet-stream';
 
@@ -251,23 +261,24 @@ export function messageToEml(message) {
         ].join('\r\n');
     });
 
-    const alternativeOrRelatedBody = inlineAttachments.length > 0
-        ? [
-            `--${boundaryRelated}`,
-            `Content-Type: multipart/alternative; boundary="${boundaryAlt}"`,
-            '',
-            alternativeParts.join('\r\n'),
-            ...relatedParts,
-            `--${boundaryRelated}--`,
-            ''
-        ].join('\r\n')
-        : alternativeParts.join('\r\n');
+    const alternativeOrRelatedBody =
+        inlineAttachments.length > 0
+            ? [
+                  `--${boundaryRelated}`,
+                  `Content-Type: multipart/alternative; boundary="${boundaryAlt}"`,
+                  '',
+                  alternativeParts.join('\r\n'),
+                  ...relatedParts,
+                  `--${boundaryRelated}--`,
+                  ''
+              ].join('\r\n')
+            : alternativeParts.join('\r\n');
 
     if (regularAttachments.length === 0) {
         return `${headers.join('\r\n')}\r\n\r\n${alternativeOrRelatedBody}`;
     }
 
-    const attachmentParts = regularAttachments.map(attachment => {
+    const attachmentParts = regularAttachments.map((attachment) => {
         const fileName = sanitizeFileComponent(attachment.fileName || 'attachment');
         const mimeType = attachment.attachMimeTag || 'application/octet-stream';
 
@@ -299,34 +310,45 @@ export function messageToEml(message) {
 
 export function messageToHtmlDocument(message) {
     const recipientsTo = (message?.recipients || [])
-        .filter(recipient => recipient.recipType === 'to')
-        .map(recipient => `${recipient.name || recipient.smtpAddress || recipient.email || ''} &lt;${recipient.smtpAddress || recipient.email || ''}&gt;`)
+        .filter((recipient) => recipient.recipType === 'to')
+        .map(
+            (recipient) =>
+                `${recipient.name || recipient.smtpAddress || recipient.email || ''} &lt;${recipient.smtpAddress || recipient.email || ''}&gt;`
+        )
         .join(', ');
     const recipientsCc = (message?.recipients || [])
-        .filter(recipient => recipient.recipType === 'cc')
-        .map(recipient => `${recipient.name || recipient.smtpAddress || recipient.email || ''} &lt;${recipient.smtpAddress || recipient.email || ''}&gt;`)
+        .filter((recipient) => recipient.recipType === 'cc')
+        .map(
+            (recipient) =>
+                `${recipient.name || recipient.smtpAddress || recipient.email || ''} &lt;${recipient.smtpAddress || recipient.email || ''}&gt;`
+        )
         .join(', ');
 
-    const bodyHtml = message?.bodyContentHTML
-        || `<pre>${escapeHTML(message?.bodyContent || '')}</pre>`;
+    const bodyHtml =
+        message?.bodyContentHTML || `<pre>${escapeHTML(message?.bodyContent || '')}</pre>`;
     const { regularAttachments } = partitionAttachments(bodyHtml, message?.attachments || []);
     const headerMap = getHeaderMap(message);
     const replyTo = getRawHeader(message, 'reply-to');
     const messageId = getRawHeader(message, 'message-id') || message?.messageId || '';
 
-    const attachmentsHtml = regularAttachments.length > 0
-        ? `
+    const attachmentsHtml =
+        regularAttachments.length > 0
+            ? `
         <section class="attachments">
             <h2>Attachments</h2>
             <ul>
-                ${regularAttachments.map(attachment => `
+                ${regularAttachments
+                    .map(
+                        (attachment) => `
                 <li>
                     <a href="${attachment.contentBase64}" download="${escapeHTML(attachment.fileName || 'attachment')}">${escapeHTML(attachment.fileName || 'attachment')}</a>
                     <span>${escapeHTML(attachment.attachMimeTag || 'application/octet-stream')}</span>
-                </li>`).join('')}
+                </li>`
+                    )
+                    .join('')}
             </ul>
         </section>`
-        : '';
+            : '';
 
     return `<!DOCTYPE html>
 <html lang="en">

--- a/src/js/ui/AttachmentModalManager.js
+++ b/src/js/ui/AttachmentModalManager.js
@@ -1,5 +1,6 @@
 import { isTauri, openWithSystemViewer, saveFileWithDialog } from '../tauri-bridge.js';
 import { extractEml } from '../utils.js';
+import { dataUrlToArrayBuffer, decodeDataUrlText, getDataUrlBase64 } from '../encoding.js';
 
 /**
  * Manages the attachment preview modal
@@ -15,7 +16,9 @@ export class AttachmentModalManager {
 
         // Modal elements
         this.attachmentModal = document.getElementById('attachmentModal');
-        this.attachmentModalBackdrop = this.attachmentModal?.querySelector('.attachment-modal-backdrop');
+        this.attachmentModalBackdrop = this.attachmentModal?.querySelector(
+            '.attachment-modal-backdrop'
+        );
         this.attachmentModalClose = document.getElementById('attachmentModalClose');
         this.attachmentModalDownload = document.getElementById('attachmentModalDownload');
         this.attachmentModalFilename = document.getElementById('attachmentModalFilename');
@@ -85,10 +88,13 @@ export class AttachmentModalManager {
     findAttachmentBySource(source) {
         if (!source) return null;
 
-        return this.currentAttachments.find(attachment =>
-            this.isPreviewableImage(attachment.attachMimeTag) &&
-            attachment.contentBase64 === source
-        ) || null;
+        return (
+            this.currentAttachments.find(
+                (attachment) =>
+                    this.isPreviewableImage(attachment.attachMimeTag) &&
+                    attachment.contentBase64 === source
+            ) || null
+        );
     }
 
     /**
@@ -233,7 +239,11 @@ export class AttachmentModalManager {
         this.attachmentModalZoomOut?.addEventListener('click', () => this.zoomOut());
         this.attachmentModalZoomReset?.addEventListener('click', () => this.resetZoom());
         this.attachmentModalZoomIn?.addEventListener('click', () => this.zoomIn());
-        this.attachmentModalContent?.addEventListener('wheel', (event) => this.handleModalWheel(event), { passive: false });
+        this.attachmentModalContent?.addEventListener(
+            'wheel',
+            (event) => this.handleModalWheel(event),
+            { passive: false }
+        );
     }
 
     /**
@@ -305,12 +315,14 @@ export class AttachmentModalManager {
     isText(mimeType) {
         if (!mimeType) return false;
         const normalizedMime = mimeType.toLowerCase();
-        return normalizedMime.startsWith('text/') ||
-               normalizedMime.startsWith('application/text') ||
-               normalizedMime === 'application/json' ||
-               normalizedMime === 'application/xml' ||
-               normalizedMime === 'application/javascript' ||
-               normalizedMime === 'application/x-diff';
+        return (
+            normalizedMime.startsWith('text/') ||
+            normalizedMime.startsWith('application/text') ||
+            normalizedMime === 'application/json' ||
+            normalizedMime === 'application/xml' ||
+            normalizedMime === 'application/javascript' ||
+            normalizedMime === 'application/x-diff'
+        );
     }
 
     /**
@@ -329,7 +341,12 @@ export class AttachmentModalManager {
      * @returns {boolean} True if the attachment is previewable
      */
     isPreviewable(mimeType) {
-        return this.isPreviewableImage(mimeType) || this.isPdf(mimeType) || this.isText(mimeType) || this.isPreviewableEml(mimeType);
+        return (
+            this.isPreviewableImage(mimeType) ||
+            this.isPdf(mimeType) ||
+            this.isText(mimeType) ||
+            this.isPreviewableEml(mimeType)
+        );
     }
 
     /**
@@ -346,13 +363,12 @@ export class AttachmentModalManager {
      * @param {Object} attachment - Attachment object
      */
     _openPdfWithSystemViewer(attachment) {
-        openWithSystemViewer(attachment.contentBase64, attachment.fileName)
-            .catch(err => {
-                console.error('Failed to open PDF with system viewer:', err);
-                if (this.showToast) {
-                    this.showToast('Failed to open PDF', 'error');
-                }
-            });
+        openWithSystemViewer(attachment.contentBase64, attachment.fileName).catch((err) => {
+            console.error('Failed to open PDF with system viewer:', err);
+            if (this.showToast) {
+                this.showToast('Failed to open PDF', 'error');
+            }
+        });
     }
 
     /**
@@ -374,14 +390,16 @@ export class AttachmentModalManager {
 
         // Build list of previewable attachments if not already set
         if (this.currentAttachments) {
-            this.previewableAttachments = this.currentAttachments.filter(att =>
+            this.previewableAttachments = this.currentAttachments.filter((att) =>
                 this.isPreviewable(att.attachMimeTag)
             );
         }
 
         // Find the index in previewable attachments
-        this.currentAttachmentIndex = this.previewableAttachments.findIndex(att =>
-            att.fileName === attachment.fileName && att.contentBase64 === attachment.contentBase64
+        this.currentAttachmentIndex = this.previewableAttachments.findIndex(
+            (att) =>
+                att.fileName === attachment.fileName &&
+                att.contentBase64 === attachment.contentBase64
         );
         if (this.currentAttachmentIndex === -1) this.currentAttachmentIndex = 0;
 
@@ -408,7 +426,9 @@ export class AttachmentModalManager {
 
         // Set filename with breadcrumb if navigating from nested content
         this.updateFilenameWithBreadcrumb(attachment.fileName);
-        this.updateSourceLink(this.inlineImageMetadataBySource.get(attachment.contentBase64)?.linkHref || '');
+        this.updateSourceLink(
+            this.inlineImageMetadataBySource.get(attachment.contentBase64)?.linkHref || ''
+        );
 
         // Set download link
         this.attachmentModalDownload.href = attachment.contentBase64;
@@ -429,13 +449,12 @@ export class AttachmentModalManager {
             pdfObject.innerHTML = `<p class="text-center p-4">PDF cannot be displayed. <a href="${attachment.contentBase64}" download="${attachment.fileName}" class="text-blue-500 underline">Download here</a></p>`;
             this.attachmentModalContent.appendChild(pdfObject);
         } else if (this.isText(attachment.attachMimeTag)) {
-            // Decode base64 to text
             try {
-                const base64Data = attachment.contentBase64?.split(',')[1];
+                const base64Data = getDataUrlBase64(attachment.contentBase64);
                 if (!base64Data) {
                     throw new Error('Invalid base64 data format');
                 }
-                const textContent = atob(base64Data);
+                const textContent = decodeDataUrlText(attachment.contentBase64);
 
                 const pre = document.createElement('pre');
                 pre.className = 'attachment-text-preview';
@@ -482,9 +501,13 @@ export class AttachmentModalManager {
         this.currentImagePreview = { viewer, stage, image: img };
         this.updateZoomControls();
 
-        img.addEventListener('load', () => {
-            this.applyImageZoom({ preserveViewport: false });
-        }, { once: true });
+        img.addEventListener(
+            'load',
+            () => {
+                this.applyImageZoom({ preserveViewport: false });
+            },
+            { once: true }
+        );
 
         if (img.complete) {
             queueMicrotask(() => this.applyImageZoom({ preserveViewport: false }));
@@ -572,8 +595,12 @@ export class AttachmentModalManager {
 
         const previousStageWidth = stage.scrollWidth || stage.clientWidth || viewerWidth;
         const previousStageHeight = stage.scrollHeight || stage.clientHeight || viewerHeight;
-        const centerRatioX = preserveViewport ? (viewer.scrollLeft + (viewerWidth / 2)) / previousStageWidth : 0.5;
-        const centerRatioY = preserveViewport ? (viewer.scrollTop + (viewerHeight / 2)) / previousStageHeight : 0.5;
+        const centerRatioX = preserveViewport
+            ? (viewer.scrollLeft + viewerWidth / 2) / previousStageWidth
+            : 0.5;
+        const centerRatioY = preserveViewport
+            ? (viewer.scrollTop + viewerHeight / 2) / previousStageHeight
+            : 0.5;
 
         const scaledWidth = Math.max(1, Math.round(baseWidth * this.imageZoomLevel));
         const scaledHeight = Math.max(1, Math.round(baseHeight * this.imageZoomLevel));
@@ -586,8 +613,14 @@ export class AttachmentModalManager {
         stage.style.height = `${stageHeight}px`;
 
         if (preserveViewport) {
-            viewer.scrollLeft = Math.max(0, Math.round((centerRatioX * stageWidth) - (viewerWidth / 2)));
-            viewer.scrollTop = Math.max(0, Math.round((centerRatioY * stageHeight) - (viewerHeight / 2)));
+            viewer.scrollLeft = Math.max(
+                0,
+                Math.round(centerRatioX * stageWidth - viewerWidth / 2)
+            );
+            viewer.scrollTop = Math.max(
+                0,
+                Math.round(centerRatioY * stageHeight - viewerHeight / 2)
+            );
         } else {
             viewer.scrollLeft = Math.max(0, Math.round((stageWidth - viewerWidth) / 2));
             viewer.scrollTop = Math.max(0, Math.round((stageHeight - viewerHeight) / 2));
@@ -649,15 +682,18 @@ export class AttachmentModalManager {
         }
 
         if (this.attachmentModalZoomOut) {
-            this.attachmentModalZoomOut.disabled = !hasImagePreview || this.imageZoomLevel <= this.minImageZoom;
+            this.attachmentModalZoomOut.disabled =
+                !hasImagePreview || this.imageZoomLevel <= this.minImageZoom;
         }
 
         if (this.attachmentModalZoomReset) {
-            this.attachmentModalZoomReset.disabled = !hasImagePreview || this.imageZoomLevel === this.minImageZoom;
+            this.attachmentModalZoomReset.disabled =
+                !hasImagePreview || this.imageZoomLevel === this.minImageZoom;
         }
 
         if (this.attachmentModalZoomIn) {
-            this.attachmentModalZoomIn.disabled = !hasImagePreview || this.imageZoomLevel >= this.maxImageZoom;
+            this.attachmentModalZoomIn.disabled =
+                !hasImagePreview || this.imageZoomLevel >= this.maxImageZoom;
         }
     }
 
@@ -719,7 +755,8 @@ export class AttachmentModalManager {
      */
     updateBackButton() {
         if (this.attachmentModalBack) {
-            this.attachmentModalBack.style.display = this.navigationStack.length > 0 ? 'flex' : 'none';
+            this.attachmentModalBack.style.display =
+                this.navigationStack.length > 0 ? 'flex' : 'none';
         }
     }
 
@@ -781,21 +818,12 @@ export class AttachmentModalManager {
      */
     renderNestedEmailPreview(attachment) {
         try {
-            const base64Data = attachment.contentBase64?.split(',')[1];
+            const base64Data = getDataUrlBase64(attachment.contentBase64);
             if (!base64Data) {
                 throw new Error('Invalid base64 data format');
             }
 
-            // Decode base64 to text
-            const emlContent = decodeURIComponent(escape(atob(base64Data)));
-
-            // Convert string to ArrayBuffer for extractEml
-            const encoder = new TextEncoder();
-            const uint8Array = encoder.encode(emlContent);
-            const arrayBuffer = uint8Array.buffer;
-
-            // Parse the EML content
-            const emailData = extractEml(arrayBuffer);
+            const emailData = extractEml(dataUrlToArrayBuffer(attachment.contentBase64));
 
             // Create structured email preview
             const emailContainer = document.createElement('div');
@@ -806,14 +834,24 @@ export class AttachmentModalManager {
             headerSection.className = 'nested-email-header';
 
             const headerFields = [
-                { label: 'From', value: emailData.senderName ? `${emailData.senderName} <${emailData.senderEmail}>` : emailData.senderEmail },
+                {
+                    label: 'From',
+                    value: emailData.senderName
+                        ? `${emailData.senderName} <${emailData.senderEmail}>`
+                        : emailData.senderEmail
+                },
                 { label: 'To', value: this.formatRecipients(emailData.recipients, 'to') },
                 { label: 'CC', value: this.formatRecipients(emailData.recipients, 'cc') },
                 { label: 'Subject', value: emailData.subject },
-                { label: 'Date', value: emailData.messageDeliveryTime ? new Date(emailData.messageDeliveryTime).toLocaleString() : '' }
+                {
+                    label: 'Date',
+                    value: emailData.messageDeliveryTime
+                        ? new Date(emailData.messageDeliveryTime).toLocaleString()
+                        : ''
+                }
             ];
 
-            headerFields.forEach(field => {
+            headerFields.forEach((field) => {
                 if (field.value) {
                     const row = document.createElement('div');
                     row.className = 'nested-email-header-row';
@@ -871,7 +909,7 @@ export class AttachmentModalManager {
                 const attachmentsList = document.createElement('div');
                 attachmentsList.className = 'nested-email-attachments-list';
 
-                emailData.attachments.forEach(att => {
+                emailData.attachments.forEach((att) => {
                     const isPreviewable = this.isPreviewable(att.attachMimeTag);
                     const isImage = this.isPreviewableImage(att.attachMimeTag);
                     const isPdf = this.isPdf(att.attachMimeTag);
@@ -907,7 +945,8 @@ export class AttachmentModalManager {
                     if (isPreviewable) {
                         // Clickable card for previewable attachments
                         const attItem = document.createElement('div');
-                        attItem.className = 'nested-email-attachment-item nested-email-attachment-previewable cursor-pointer';
+                        attItem.className =
+                            'nested-email-attachment-item nested-email-attachment-previewable cursor-pointer';
                         attItem.title = 'Click to preview';
                         attItem.innerHTML = `
                             <div class="attachment-thumbnail w-10 h-10 shrink-0 flex items-center justify-center overflow-hidden">
@@ -966,7 +1005,6 @@ export class AttachmentModalManager {
             }
 
             this.attachmentModalContent.appendChild(emailContainer);
-
         } catch (error) {
             console.error('Error rendering nested email:', error);
             const errorDiv = document.createElement('div');
@@ -985,8 +1023,8 @@ export class AttachmentModalManager {
     formatRecipients(recipients, type) {
         if (!recipients || !Array.isArray(recipients)) return '';
         return recipients
-            .filter(recipient => recipient.recipType === type)
-            .map(recipient => {
+            .filter((recipient) => recipient.recipType === type)
+            .map((recipient) => {
                 const name = recipient.name || '';
                 // Prefer smtpAddress over email (email may contain Exchange X.500 DN)
                 const email = recipient.smtpAddress || recipient.email || recipient.address || '';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,12 +1,27 @@
 import MsgReaderLib from '@kenjiuno/msgreader';
 import { decompressRTF } from '@kenjiuno/decompressrtf';
 import { deEncapsulateSync } from 'rtf-stream-parser';
-import iconvLite from 'iconv-lite';
 import { Buffer } from 'buffer';
 
-import { getCharsetFromCodepage } from './helpers.js';
-import { BASE64_SIZE_FACTOR } from './constants.js';
+import {
+    escapeRegex,
+    extractBaseMimeType,
+    extractBoundary,
+    extractCharset,
+    getCharsetFromCodepage
+} from './helpers.js';
+import { BASE64_SIZE_FACTOR, DEFAULT_CHARSET } from './constants.js';
 import { replaceCidReferences } from './cidReplacer.js';
+import {
+    binaryStringToBase64,
+    decodeBase64Text,
+    decodeBinaryString,
+    decodeBytes,
+    decodeMimeWords,
+    decodePercentEncodedText,
+    decodeQuotedPrintable,
+    textToBase64
+} from './encoding.js';
 
 /**
  * Sanitizes attachment filenames to prevent path traversal attacks
@@ -19,17 +34,17 @@ function sanitizeFilename(filename) {
 
     let sanitized = filename
         // Remove path traversal sequences
-        .replace(/\.\.\//g, '')            // Remove ../
-        .replace(/\.\.\\/g, '')            // Remove ..\
-        .replace(/^\/+/g, '')              // Remove leading forward slashes
-        .replace(/^[A-Za-z]:[\\/]/g, '')  // Remove Windows drive letters (C:\, D:/)
+        .replace(/\.\.\//g, '') // Remove ../
+        .replace(/\.\.\\/g, '') // Remove ..\
+        .replace(/^\/+/g, '') // Remove leading forward slashes
+        .replace(/^[A-Za-z]:[\\/]/g, '') // Remove Windows drive letters (C:\, D:/)
         // Remove control characters
         // eslint-disable-next-line no-control-regex
-        .replace(/[\x00-\x1f\x7f]/g, '')   // Remove control characters (including null)
-        .replace(/\ufeff/g, '')            // Remove UTF-16 BOM
-        .replace(/\ufffd/g, '')            // Remove replacement character
+        .replace(/[\x00-\x1f\x7f]/g, '') // Remove control characters (including null)
+        .replace(/\ufeff/g, '') // Remove UTF-16 BOM
+        .replace(/\ufffd/g, '') // Remove replacement character
         // Replace Windows reserved characters
-        .replace(/[<>:"|?*]/g, '_')        // Replace chars invalid in Windows filenames
+        .replace(/[<>:"|?*]/g, '_') // Replace chars invalid in Windows filenames
         // Remove trailing encoding artifacts from MIME (e.g., _= or trailing =)
         .replace(/[_=]+$/, '')
         .trim();
@@ -129,28 +144,101 @@ function resolveMsgAttachmentFilename(attachment, attachmentFileName = '') {
  * @returns {string} Decoded string
  */
 function decodeMIMEWord(str) {
-    if (!str) return '';
+    return decodeMimeWords(str);
+}
 
-    // Replace all encoded words in the string
-    return str.replace(/=\?([^?]+)\?([BQbq])\?([^?]*)\?=/g, (match, charset, encoding, text) => {
-        try {
-            if (encoding.toUpperCase() === 'B') {
-                // Base64 encoded
-                const bytes = atob(text);
-                return iconvLite.decode(Buffer.from(bytes, 'binary'), charset);
-            } else if (encoding.toUpperCase() === 'Q') {
-                // Quoted-printable encoded
-                text = text.replace(/_/g, ' ');
-                const bytes = text.replace(/=([0-9A-F]{2})/gi, (_, hex) =>
-                    String.fromCharCode(parseInt(hex, 16))
-                );
-                return iconvLite.decode(Buffer.from(bytes, 'binary'), charset);
-            }
-        } catch (error) {
-            console.error('Error decoding MIME word:', error);
+function splitHeaderParameters(headerValue) {
+    const parts = [];
+    let current = '';
+    let inQuotes = false;
+    let escaped = false;
+
+    for (const char of headerValue || '') {
+        if (escaped) {
+            current += char;
+            escaped = false;
+            continue;
         }
-        return match; // Return original string if decoding fails
-    });
+
+        if (char === '\\' && inQuotes) {
+            current += char;
+            escaped = true;
+            continue;
+        }
+
+        if (char === '"') {
+            inQuotes = !inQuotes;
+            current += char;
+            continue;
+        }
+
+        if (char === ';' && !inQuotes) {
+            parts.push(current.trim());
+            current = '';
+            continue;
+        }
+
+        current += char;
+    }
+
+    if (current.trim()) {
+        parts.push(current.trim());
+    }
+
+    return parts;
+}
+
+function unquoteHeaderValue(value) {
+    const trimmed = (value || '').trim();
+    if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+        return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+    }
+    return trimmed;
+}
+
+function parseHeaderParameters(headerValue) {
+    return splitHeaderParameters(headerValue)
+        .slice(1)
+        .reduce((params, part) => {
+            const equalsIndex = part.indexOf('=');
+            if (equalsIndex === -1) return params;
+
+            const name = part.slice(0, equalsIndex).trim().toLowerCase();
+            const value = unquoteHeaderValue(part.slice(equalsIndex + 1));
+            if (name) {
+                params[name] = value;
+            }
+
+            return params;
+        }, {});
+}
+
+function decodeRfc2231Value(value) {
+    const match = (value || '').match(/^([^']*)'[^']*'(.*)$/);
+    if (match) {
+        return decodePercentEncodedText(match[2], match[1] || DEFAULT_CHARSET);
+    }
+
+    return decodePercentEncodedText(value, DEFAULT_CHARSET);
+}
+
+function decodeRfc2231Parameter(params, parameterName) {
+    const directValue = params[`${parameterName}*`];
+    if (directValue) {
+        return decodeRfc2231Value(directValue);
+    }
+
+    const segments = Object.keys(params)
+        .map((key) => {
+            const match = key.match(new RegExp(`^${parameterName}\\*(\\d+)(\\*)?$`, 'i'));
+            return match ? { key, index: Number(match[1]) } : null;
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.index - b.index);
+
+    if (segments.length === 0) return '';
+
+    return decodeRfc2231Value(segments.map((segment) => params[segment.key] || '').join(''));
 }
 
 /**
@@ -158,32 +246,23 @@ function decodeMIMEWord(str) {
  * Handles RFC 2231 encoding and MIME encoded-words
  * @param {string} contentDisposition - Content-Disposition header value
  * @param {string} [defaultName='attachment'] - Default filename if none found
+ * @param {string} [contentType=''] - Content-Type header value, used for name fallback
  * @returns {string} Extracted filename
  */
-function extractFilename(contentDisposition, defaultName = 'attachment') {
-    if (!contentDisposition) return defaultName;
+function extractFilename(contentDisposition, defaultName = 'attachment', contentType = '') {
+    const dispositionParams = parseHeaderParameters(contentDisposition);
+    const contentTypeParams = parseHeaderParameters(contentType);
 
-    // Try RFC 2231 format first: filename*=UTF-8''encoded_value
-    const rfc2231Match = contentDisposition.match(/filename\*=([^']*)'([^']*)'([^;\s]+)/i);
-    if (rfc2231Match) {
-        const encoded = rfc2231Match[3];
-        try {
-            // Decode percent-encoded characters
-            return decodeURIComponent(encoded);
-        } catch (error) {
-            console.error('Error decoding RFC 2231 filename:', error);
-        }
+    const encodedFilename =
+        decodeRfc2231Parameter(dispositionParams, 'filename') ||
+        decodeRfc2231Parameter(contentTypeParams, 'name');
+    if (encodedFilename) {
+        return encodedFilename.replace(/[_=]+$/, '');
     }
 
-    // Try standard filename with potential MIME encoding
-    const filenameMatch = contentDisposition.match(/filename="?([^";\n]+)"?/i);
-    if (filenameMatch) {
-        let filename = filenameMatch[1];
-        // Decode MIME words if present
-        filename = decodeMIMEWord(filename);
-        // Remove trailing artifacts from incomplete encoding (e.g., _= or trailing =)
-        filename = filename.replace(/[_=]+$/, '');
-        return filename;
+    const plainFilename = dispositionParams.filename || contentTypeParams.name;
+    if (plainFilename) {
+        return decodeMIMEWord(plainFilename).replace(/[_=]+$/, '');
     }
 
     return defaultName;
@@ -199,7 +278,7 @@ export function parseEmailHeaders(headerString) {
     const headers = {};
     let currentHeader = '';
 
-    headerString.split(/\r?\n/).forEach(line => {
+    headerString.split(/\r?\n/).forEach((line) => {
         if (line.match(/^\s+/)) {
             // Continuation of previous header (folded header)
             if (currentHeader) {
@@ -231,8 +310,7 @@ function decodeTransferEncoding(content, encoding, charset, isText = true) {
     if (normalizedEncoding === 'base64') {
         if (isText) {
             try {
-                const decodedBytes = Buffer.from(content.replace(/\s/g, ''), 'base64');
-                return iconvLite.decode(decodedBytes, charset);
+                return decodeBase64Text(content, charset);
             } catch (error) {
                 console.error('Error decoding base64 content:', error);
                 return content;
@@ -240,15 +318,10 @@ function decodeTransferEncoding(content, encoding, charset, isText = true) {
         }
         return content; // Return raw for non-text
     } else if (normalizedEncoding === 'quoted-printable') {
-        // Decode quoted-printable: remove soft line breaks, then decode hex codes
-        const qpContent = content
-            .replace(/=\r?\n/g, '')
-            .replace(/=([0-9A-F]{2})/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
-        const decodedBytes = Buffer.from(qpContent, 'binary');
-        return iconvLite.decode(decodedBytes, charset);
+        return decodeQuotedPrintable(content, charset);
     }
 
-    return content.trim();
+    return decodeBinaryString(content, charset, { trim: true });
 }
 
 /**
@@ -260,7 +333,7 @@ function extractEmailAddresses(str) {
     if (!str) return [];
 
     const matches = str.match(/(?:"([^"]*)")?\s*(?:<([^>]+)>|([^\s,]+@[^\s,]+))/g) || [];
-    return matches.map(match => {
+    return matches.map((match) => {
         const parts = match.match(/(?:"([^"]*)")?\s*(?:<([^>]+)>|([^\s,]+@[^\s,]+))/);
         const email = parts[2] || parts[3];
         const name = parts[1] || email;
@@ -299,17 +372,17 @@ function createAttachment(filename, mimeType, base64Content, contentId = null) {
  * @param {string} [defaultCharset='utf-8'] - Default charset
  * @returns {{bodyHTML: string, bodyText: string, attachments: Array}} Parsed content
  */
-function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'utf-8') {
+function parseMultipartContent(content, boundary, depth = 0, defaultCharset = DEFAULT_CHARSET) {
     const results = {
         bodyHTML: '',
         bodyText: '',
         attachments: []
     };
 
-    const boundaryRegExp = new RegExp(`--${boundary}(?:--)?(?:\r?\n|\r|$)`, 'g');
-    const parts = content.split(boundaryRegExp).filter(part => part.trim());
+    const boundaryRegExp = new RegExp(`--${escapeRegex(boundary)}(?:--)?(?:\r?\n|\r|$)`, 'g');
+    const parts = content.split(boundaryRegExp).filter((part) => part.trim());
 
-    parts.forEach(part => {
+    parts.forEach((part) => {
         const partMatch = part.match(/^([\s\S]*?)\r?\n\r?\n([\s\S]*)$/);
         if (!partMatch) return;
 
@@ -317,20 +390,21 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
         const partHeaders = parseEmailHeaders(partHeadersStr);
 
         const contentType = partHeaders['content-type'] || '';
+        const baseContentType = extractBaseMimeType(contentType);
         const contentTransferEncoding = partHeaders['content-transfer-encoding'] || '';
         const contentDisposition = partHeaders['content-disposition'] || '';
         const contentId = partHeaders['content-id'] || '';
 
-        // Extract charset from part's content-type
-        const partCharsetMatch = contentType.match(/charset="?([^";\s]+)"?/i);
-        const partCharset = partCharsetMatch ? partCharsetMatch[1] : defaultCharset;
+        const partCharset = /charset\s*=/i.test(contentType)
+            ? extractCharset(contentType)
+            : defaultCharset;
 
         // Check for nested multipart
-        const nestedBoundaryMatch = contentType.match(/boundary="?([^";\s]+)"?/);
-        if (nestedBoundaryMatch) {
+        const nestedBoundary = extractBoundary(contentType);
+        if (nestedBoundary) {
             const nestedResults = parseMultipartContent(
                 partContent,
-                nestedBoundaryMatch[1],
+                nestedBoundary,
                 depth + 1,
                 partCharset
             );
@@ -355,8 +429,8 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
         // Decode and handle content based on type
         if (isExplicitAttachment) {
             // Treat as attachment regardless of content-type
-            const filename = extractFilename(contentDisposition);
-            const mimeType = contentType.split(';')[0] || 'application/octet-stream';
+            const filename = extractFilename(contentDisposition, 'attachment', contentType);
+            const mimeType = baseContentType || 'application/octet-stream';
 
             let base64Content;
             if (contentTransferEncoding.toLowerCase() === 'base64') {
@@ -368,12 +442,12 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
                     contentTransferEncoding,
                     partCharset
                 );
-                base64Content = btoa(unescape(encodeURIComponent(decodedContent)));
+                base64Content = textToBase64(decodedContent);
             }
 
             const attachment = createAttachment(filename, mimeType, base64Content, contentId);
             results.attachments.push(attachment);
-        } else if (contentType.startsWith('text/html')) {
+        } else if (baseContentType === 'text/html') {
             const decodedContent = decodeTransferEncoding(
                 partContent.trim(),
                 contentTransferEncoding,
@@ -382,7 +456,7 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
             results.bodyHTML = results.bodyHTML
                 ? results.bodyHTML + '\n' + decodedContent
                 : decodedContent;
-        } else if (contentType.startsWith('text/plain')) {
+        } else if (baseContentType === 'text/plain') {
             const decodedContent = decodeTransferEncoding(
                 partContent.trim(),
                 contentTransferEncoding,
@@ -391,15 +465,18 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
             results.bodyText = results.bodyText
                 ? results.bodyText + '\n' + decodedContent
                 : decodedContent;
-        } else if (contentType.startsWith('image/') || contentType.startsWith('application/')) {
-            const filename = extractFilename(contentDisposition);
-            const mimeType = contentType.split(';')[0];
+        } else if (
+            baseContentType.startsWith('image/') ||
+            baseContentType.startsWith('application/')
+        ) {
+            const filename = extractFilename(contentDisposition, 'attachment', contentType);
+            const mimeType = baseContentType;
 
             let base64Content;
             if (contentTransferEncoding.toLowerCase() === 'base64') {
                 base64Content = partContent.replace(/\s/g, '');
             } else {
-                base64Content = Buffer.from(partContent, 'binary').toString('base64');
+                base64Content = binaryStringToBase64(partContent);
             }
 
             const attachment = createAttachment(filename, mimeType, base64Content, contentId);
@@ -413,33 +490,36 @@ function parseMultipartContent(content, boundary, depth = 0, defaultCharset = 'u
             }
 
             results.attachments.push(attachment);
-        } else if (contentType.startsWith('message/')) {
+        } else if (baseContentType.startsWith('message/')) {
             // Handle nested email attachments (e.g., message/rfc822)
-            const filename = extractFilename(contentDisposition, 'embedded_message.eml');
-            const mimeType = contentType.split(';')[0];
+            const filename = extractFilename(
+                contentDisposition,
+                'embedded_message.eml',
+                contentType
+            );
+            const mimeType = baseContentType;
 
             // Encode the entire part content as base64
             let base64Content;
             if (contentTransferEncoding.toLowerCase() === 'base64') {
                 base64Content = partContent.replace(/\s/g, '');
             } else {
-                // For 7bit/8bit/quoted-printable, encode to base64
-                base64Content = btoa(unescape(encodeURIComponent(partContent)));
+                base64Content = binaryStringToBase64(partContent);
             }
 
             const attachment = createAttachment(filename, mimeType, base64Content, contentId);
             results.attachments.push(attachment);
-        } else if (contentType.startsWith('text/')) {
+        } else if (baseContentType.startsWith('text/')) {
             // Other text types (text/x-diff, text/csv, etc.) - treat as attachment if has filename
-            const filename = extractFilename(contentDisposition);
+            const filename = extractFilename(contentDisposition, 'attachment', contentType);
             if (filename && filename !== 'attachment') {
-                const mimeType = contentType.split(';')[0];
+                const mimeType = baseContentType;
                 const decodedContent = decodeTransferEncoding(
                     partContent.trim(),
                     contentTransferEncoding,
                     partCharset
                 );
-                const base64Content = btoa(unescape(encodeURIComponent(decodedContent)));
+                const base64Content = textToBase64(decodedContent);
                 const attachment = createAttachment(filename, mimeType, base64Content, contentId);
                 results.attachments.push(attachment);
             }
@@ -502,17 +582,7 @@ function extractMsgHtmlContent(msgInfo, debugData = null) {
                 debugData.charset = charset;
             }
 
-            // Try TextDecoder first, fallback to iconv-lite
-            let result;
-            if (typeof TextDecoder !== 'undefined') {
-                try {
-                    result = new TextDecoder(charset).decode(htmlArr);
-                } catch {
-                    result = iconvLite.decode(Buffer.from(htmlArr), charset);
-                }
-            } else {
-                result = iconvLite.decode(Buffer.from(htmlArr), charset);
-            }
+            const result = decodeBytes(htmlArr, charset);
 
             if (debugData) {
                 debugData.htmlBeforeCid = result;
@@ -532,13 +602,15 @@ function extractMsgHtmlContent(msgInfo, debugData = null) {
             if (debugData) {
                 debugData.htmlSource = 'rtf';
                 debugData.compressedRtf = compressedRtfArr;
-                debugData.decompressedRtf = typeof decompressedRtf === 'string'
-                    ? decompressedRtf
-                    : new TextDecoder('latin1').decode(
-                        decompressedRtf instanceof Uint8Array
-                            ? decompressedRtf
-                            : Uint8Array.from(Object.values(decompressedRtf))
-                    );
+                debugData.decompressedRtf =
+                    typeof decompressedRtf === 'string'
+                        ? decompressedRtf
+                        : decodeBytes(
+                              decompressedRtf instanceof Uint8Array
+                                  ? decompressedRtf
+                                  : Uint8Array.from(Object.values(decompressedRtf)),
+                              'latin1'
+                          );
             }
 
             const result = convertRTFToHTML(decompressedRtf);
@@ -569,7 +641,7 @@ function extractMsgHtmlContent(msgInfo, debugData = null) {
  * @returns {Array} Processed attachments with base64 content
  */
 function processMsgAttachments(msgReader, attachments) {
-    return attachments.map(attachment => {
+    return attachments.map((attachment) => {
         const attachmentData = msgReader.getAttachment(attachment);
         const contentUint8Array = attachmentData.content;
         const contentBuffer = Buffer.from(contentUint8Array);
@@ -606,12 +678,14 @@ export function extractMsg(fileBuffer, options = {}) {
     const { collectDebugData = false } = options;
 
     // Initialize debug data object if collecting
-    const debugData = collectDebugData ? {
-        fileType: 'msg',
-        rawSize: fileBuffer.byteLength,
-        rawBuffer: fileBuffer,
-        timestamp: new Date().toISOString()
-    } : null;
+    const debugData = collectDebugData
+        ? {
+              fileType: 'msg',
+              rawSize: fileBuffer.byteLength,
+              rawBuffer: fileBuffer,
+              timestamp: new Date().toISOString()
+          }
+        : null;
 
     const result = initializeMsgReader(fileBuffer);
     if (!result) return null;
@@ -622,16 +696,18 @@ export function extractMsg(fileBuffer, options = {}) {
     // Store raw msgInfo for debug
     if (debugData) {
         // Create a clean copy without circular references
-        debugData.msgInfoRaw = JSON.parse(JSON.stringify(msgInfo, (key, value) => {
-            // Skip large binary data in JSON representation
-            if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
-                return `[Binary: ${value.byteLength || value.length} bytes]`;
-            }
-            if (key === 'content' && typeof value === 'object') {
-                return '[Attachment content]';
-            }
-            return value;
-        }));
+        debugData.msgInfoRaw = JSON.parse(
+            JSON.stringify(msgInfo, (key, value) => {
+                // Skip large binary data in JSON representation
+                if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+                    return `[Binary: ${value.byteLength || value.length} bytes]`;
+                }
+                if (key === 'content' && typeof value === 'object') {
+                    return '[Attachment content]';
+                }
+                return value;
+            })
+        );
         debugData.plainText = emailBodyContent;
     }
 
@@ -651,7 +727,7 @@ export function extractMsg(fileBuffer, options = {}) {
         if (debugData) {
             debugData.htmlAfterCid = emailBodyContentHTML;
             debugData.attachmentCount = msgInfo.attachments.length;
-            debugData.attachments = msgInfo.attachments.map(a => ({
+            debugData.attachments = msgInfo.attachments.map((a) => ({
                 fileName: a.fileName,
                 mimeType: a.attachMimeTag,
                 contentLength: a.contentLength,
@@ -691,13 +767,14 @@ function convertRTFToHTML(rtfContent) {
     // decompressRTF may return an array-like object, convert to string
     let rtfString = rtfContent;
     if (typeof rtfContent !== 'string') {
-        const arr = rtfContent instanceof Uint8Array
-            ? rtfContent
-            : Uint8Array.from(Object.values(rtfContent));
-        rtfString = new TextDecoder('latin1').decode(arr);
+        const arr =
+            rtfContent instanceof Uint8Array
+                ? rtfContent
+                : Uint8Array.from(Object.values(rtfContent));
+        rtfString = decodeBytes(arr, 'latin1');
     }
 
-    const result = deEncapsulateSync(rtfString, { decode: iconvLite.decode });
+    const result = deEncapsulateSync(rtfString, { decode: decodeBytes });
     return result.text;
 }
 
@@ -710,28 +787,40 @@ function convertRTFToHTML(rtfContent) {
  * @param {string} charset - Character set for decoding
  * @returns {{bodyHTML: string, bodyText: string, attachments: Array}} Parsed content
  */
-function handleSinglePartContent(bodyContent, contentType, contentTransferEncoding, contentDisposition, charset) {
+function handleSinglePartContent(
+    bodyContent,
+    contentType,
+    contentTransferEncoding,
+    contentDisposition,
+    charset
+) {
     const results = {
         bodyHTML: '',
         bodyText: '',
         attachments: []
     };
+    const baseContentType = extractBaseMimeType(contentType);
 
-    if (contentType.startsWith('application/') || contentType.startsWith('image/')) {
+    if (baseContentType.startsWith('application/') || baseContentType.startsWith('image/')) {
         // Handle as attachment
-        const filename = extractFilename(contentDisposition);
-        const mimeType = contentType.split(';')[0];
+        const filename = extractFilename(contentDisposition, 'attachment', contentType);
+        const mimeType = baseContentType;
 
-        const base64Content = contentTransferEncoding.toLowerCase() === 'base64'
-            ? bodyContent.replace(/\s/g, '')
-            : Buffer.from(bodyContent).toString('base64');
+        const base64Content =
+            contentTransferEncoding.toLowerCase() === 'base64'
+                ? bodyContent.replace(/\s/g, '')
+                : binaryStringToBase64(bodyContent);
 
         results.attachments.push(createAttachment(filename, mimeType, base64Content));
     } else {
         // Handle as text content
-        const decodedContent = decodeTransferEncoding(bodyContent, contentTransferEncoding, charset);
+        const decodedContent = decodeTransferEncoding(
+            bodyContent,
+            contentTransferEncoding,
+            charset
+        );
 
-        if (contentType.includes('text/html')) {
+        if (baseContentType === 'text/html') {
             results.bodyHTML = decodedContent;
         } else {
             results.bodyText = decodedContent;
@@ -753,12 +842,14 @@ export function extractEml(fileBuffer, options = {}) {
     const { collectDebugData = false } = options;
 
     // Initialize debug data object if collecting
-    const debugData = collectDebugData ? {
-        fileType: 'eml',
-        rawSize: fileBuffer.byteLength,
-        rawBuffer: fileBuffer,
-        timestamp: new Date().toISOString()
-    } : null;
+    const debugData = collectDebugData
+        ? {
+              fileType: 'eml',
+              rawSize: fileBuffer.byteLength,
+              rawBuffer: fileBuffer,
+              timestamp: new Date().toISOString()
+          }
+        : null;
 
     try {
         // Convert ArrayBuffer to String
@@ -790,27 +881,28 @@ export function extractEml(fileBuffer, options = {}) {
 
         // Extract content type info
         const contentType = headers['content-type'] || '';
-        const boundaryMatch = contentType.match(/boundary="?([^";\s]+)"?/);
-        const charsetMatch = contentType.match(/charset="?([^";\s]+)"?/i);
-        const detectedCharset = charsetMatch ? charsetMatch[1] : 'utf-8';
+        const boundary = extractBoundary(contentType);
+        const detectedCharset = /charset\s*=/i.test(contentType)
+            ? extractCharset(contentType)
+            : DEFAULT_CHARSET;
 
         if (debugData) {
             debugData.contentType = contentType;
             debugData.charset = detectedCharset;
-            debugData.isMultipart = !!boundaryMatch;
-            debugData.boundary = boundaryMatch ? boundaryMatch[1] : null;
+            debugData.isMultipart = !!boundary;
+            debugData.boundary = boundary || null;
         }
 
         // Parse content based on whether it's multipart or single-part
         let results;
         let htmlBeforeCid = '';
 
-        if (boundaryMatch) {
+        if (boundary) {
             // Multipart email
-            results = parseMultipartContent(bodyContent, boundaryMatch[1], 0, detectedCharset);
+            results = parseMultipartContent(bodyContent, boundary, 0, detectedCharset);
 
             if (debugData) {
-                debugData.mimeStructure = buildMimeStructure(bodyContent, boundaryMatch[1]);
+                debugData.mimeStructure = buildMimeStructure(bodyContent, boundary);
             }
 
             htmlBeforeCid = results.bodyHTML;
@@ -841,7 +933,7 @@ export function extractEml(fileBuffer, options = {}) {
             debugData.plainText = results.bodyText;
             debugData.htmlFinal = results.bodyHTML || results.bodyText;
             debugData.attachmentCount = results.attachments.length;
-            debugData.attachments = results.attachments.map(a => ({
+            debugData.attachments = results.attachments.map((a) => ({
                 fileName: a.fileName,
                 mimeType: a.attachMimeTag,
                 contentLength: a.contentLength,
@@ -863,8 +955,8 @@ export function extractEml(fileBuffer, options = {}) {
             senderName: from.name || from.address,
             senderEmail: from.address,
             recipients: [
-                ...to.map(r => ({ ...r, recipType: 'to' })),
-                ...cc.map(r => ({ ...r, recipType: 'cc' }))
+                ...to.map((r) => ({ ...r, recipType: 'to' })),
+                ...cc.map((r) => ({ ...r, recipType: 'cc' }))
             ],
             messageDeliveryTime: date.toISOString(),
             bodyContent: results.bodyText,
@@ -899,8 +991,8 @@ function buildMimeStructure(content, boundary, depth = 0) {
         parts: []
     };
 
-    const boundaryRegExp = new RegExp(`--${boundary}(?:--)?(?:\r?\n|\r|$)`, 'g');
-    const parts = content.split(boundaryRegExp).filter(part => part.trim());
+    const boundaryRegExp = new RegExp(`--${escapeRegex(boundary)}(?:--)?(?:\r?\n|\r|$)`, 'g');
+    const parts = content.split(boundaryRegExp).filter((part) => part.trim());
 
     parts.forEach((part, index) => {
         const partMatch = part.match(/^([\s\S]*?)\r?\n\r?\n([\s\S]*)$/);
@@ -912,23 +1004,23 @@ function buildMimeStructure(content, boundary, depth = 0) {
 
         const partInfo = {
             index: index,
-            contentType: contentType.split(';')[0].trim(),
+            contentType: extractBaseMimeType(contentType) || 'text/plain',
             headers: partHeaders,
             size: partContent.length
         };
 
         // Check for nested multipart
-        const nestedBoundaryMatch = contentType.match(/boundary="?([^";\s]+)"?/);
-        if (nestedBoundaryMatch) {
-            partInfo.nested = buildMimeStructure(partContent, nestedBoundaryMatch[1], depth + 1);
+        const nestedBoundary = extractBoundary(contentType);
+        if (nestedBoundary) {
+            partInfo.nested = buildMimeStructure(partContent, nestedBoundary, depth + 1);
         }
 
         // Add disposition info
         if (partHeaders['content-disposition']) {
             partInfo.disposition = partHeaders['content-disposition'].split(';')[0].trim();
-            const filenameMatch = partHeaders['content-disposition'].match(/filename="?([^";\n]+)"?/i);
-            if (filenameMatch) {
-                partInfo.filename = filenameMatch[1];
+            const filename = extractFilename(partHeaders['content-disposition'], '', contentType);
+            if (filename) {
+                partInfo.filename = filename;
             }
         }
 

--- a/tests/UIManager.test.js
+++ b/tests/UIManager.test.js
@@ -213,7 +213,11 @@ describe('UIManager (Facade)', () => {
     describe('Attachment modal', () => {
         test('openAttachmentModal delegates to modal.open', () => {
             const spy = jest.spyOn(uiManager.modal, 'open');
-            const attachment = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:' };
+            const attachment = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:'
+            };
             uiManager.openAttachmentModal(attachment);
             expect(spy).toHaveBeenCalledWith(attachment);
         });
@@ -276,7 +280,9 @@ describe('UIManager (Facade)', () => {
 
             viewer.querySelector('[data-action="toggle-export-menu"]').click();
 
-            expect(viewer.querySelector('.message-export-menu').classList.contains('active')).toBe(true);
+            expect(viewer.querySelector('.message-export-menu').classList.contains('active')).toBe(
+                true
+            );
         });
 
         test('clicking export-message calls exportMessage with the selected message and format', () => {
@@ -288,7 +294,8 @@ describe('UIManager (Facade)', () => {
 
             const spy = jest.spyOn(uiManager, 'exportMessage').mockResolvedValue();
             const viewer = document.getElementById('messageViewer');
-            viewer.innerHTML = '<button data-action="export-message" data-index="0" data-format="eml">Export</button>';
+            viewer.innerHTML =
+                '<button data-action="export-message" data-index="0" data-format="eml">Export</button>';
 
             viewer.querySelector('[data-action="export-message"]').click();
 
@@ -421,8 +428,14 @@ describe('AttachmentModalManager', () => {
         isTauri.mockReturnValue(false);
         modal = new AttachmentModalManager(jest.fn());
         loadImageDimensions = (image, { naturalWidth = 1200, naturalHeight = 600 } = {}) => {
-            Object.defineProperty(image, 'naturalWidth', { configurable: true, value: naturalWidth });
-            Object.defineProperty(image, 'naturalHeight', { configurable: true, value: naturalHeight });
+            Object.defineProperty(image, 'naturalWidth', {
+                configurable: true,
+                value: naturalWidth
+            });
+            Object.defineProperty(image, 'naturalHeight', {
+                configurable: true,
+                value: naturalHeight
+            });
             image.dispatchEvent(new Event('load'));
         };
     });
@@ -467,7 +480,11 @@ describe('AttachmentModalManager', () => {
     });
 
     describe('open and close', () => {
-        const attachment = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+        const attachment = {
+            fileName: 'test.png',
+            attachMimeTag: 'image/png',
+            contentBase64: 'data:image/png;base64,abc'
+        };
 
         test('open shows modal', () => {
             modal.setAttachments([attachment]);
@@ -517,25 +534,38 @@ describe('AttachmentModalManager', () => {
         });
 
         test('openInlineImage creates synthetic preview attachments when needed', () => {
-            modal.openInlineImage({ source: 'data:image/gif;base64,abc', fileName: 'inline-preview' });
+            modal.openInlineImage({
+                source: 'data:image/gif;base64,abc',
+                fileName: 'inline-preview'
+            });
 
             expect(modal.attachmentModal.classList.contains('active')).toBe(true);
             expect(modal.previewableAttachments).toHaveLength(1);
             expect(modal.previewableAttachments[0].fileName).toBe('inline-preview.gif');
-            expect(modal.attachmentModalContent.querySelector('img').src).toContain('data:image/gif;base64,abc');
+            expect(modal.attachmentModalContent.querySelector('img').src).toContain(
+                'data:image/gif;base64,abc'
+            );
         });
     });
 
     describe('renderAttachmentPreview', () => {
         test('sets filename', () => {
-            const att = { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:' };
+            const att = {
+                fileName: 'doc.pdf',
+                attachMimeTag: 'application/pdf',
+                contentBase64: 'data:'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             expect(modal.attachmentModalFilename.textContent).toBe('doc.pdf');
         });
 
         test('sets download link', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             expect(modal.attachmentModalDownload.href).toContain('data:image/png');
@@ -543,14 +573,22 @@ describe('AttachmentModalManager', () => {
         });
 
         test('creates img for images', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             expect(modal.attachmentModalContent.querySelector('img')).toBeTruthy();
         });
 
         test('shows zoom controls for image previews', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -563,7 +601,11 @@ describe('AttachmentModalManager', () => {
         });
 
         test('hides zoom controls for non-image previews', () => {
-            const att = { fileName: 'test.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:application/pdf;base64,abc' };
+            const att = {
+                fileName: 'test.pdf',
+                attachMimeTag: 'application/pdf',
+                contentBase64: 'data:application/pdf;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -571,8 +613,14 @@ describe('AttachmentModalManager', () => {
         });
 
         test('shows the original link action for linked inline images', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
-            modal.setInlineImageMetadata(att.contentBase64, { linkHref: 'https://example.com/details' });
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
+            modal.setInlineImageMetadata(att.contentBase64, {
+                linkHref: 'https://example.com/details'
+            });
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -581,7 +629,11 @@ describe('AttachmentModalManager', () => {
         });
 
         test('hides the original link action when no source link exists', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -589,7 +641,11 @@ describe('AttachmentModalManager', () => {
         });
 
         test('zooms image previews with the toolbar controls', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -610,7 +666,11 @@ describe('AttachmentModalManager', () => {
         });
 
         test('supports Ctrl+wheel zoom for image previews', () => {
-            const att = { fileName: 'test.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,abc' };
+            const att = {
+                fileName: 'test.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
 
@@ -625,8 +685,16 @@ describe('AttachmentModalManager', () => {
         });
 
         test('resets image zoom when switching previews', () => {
-            const first = { fileName: 'first.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,first' };
-            const second = { fileName: 'second.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,second' };
+            const first = {
+                fileName: 'first.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,first'
+            };
+            const second = {
+                fileName: 'second.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,second'
+            };
             modal.setAttachments([first, second]);
 
             modal.renderAttachmentPreview(first);
@@ -634,7 +702,10 @@ describe('AttachmentModalManager', () => {
             modal.attachmentModalZoomIn.click();
 
             modal.renderAttachmentPreview(second);
-            loadImageDimensions(modal.attachmentModalContent.querySelector('img'), { naturalWidth: 800, naturalHeight: 800 });
+            loadImageDimensions(modal.attachmentModalContent.querySelector('img'), {
+                naturalWidth: 800,
+                naturalHeight: 800
+            });
 
             expect(modal.imageZoomLevel).toBe(1);
             expect(modal.attachmentModalZoomValue.textContent).toBe('100%');
@@ -642,27 +713,60 @@ describe('AttachmentModalManager', () => {
         });
 
         test('creates object for PDFs', () => {
-            const att = { fileName: 'test.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:application/pdf;base64,abc' };
+            const att = {
+                fileName: 'test.pdf',
+                attachMimeTag: 'application/pdf',
+                contentBase64: 'data:application/pdf;base64,abc'
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             expect(modal.attachmentModalContent.querySelector('object')).toBeTruthy();
         });
 
         test('creates pre for text', () => {
-            const att = { fileName: 'test.txt', attachMimeTag: 'text/plain', contentBase64: 'data:text/plain;base64,SGVsbG8=' };
+            const att = {
+                fileName: 'test.txt',
+                attachMimeTag: 'text/plain',
+                contentBase64: 'data:text/plain;base64,SGVsbG8='
+            };
             modal.setAttachments([att]);
             modal.renderAttachmentPreview(att);
             const pre = modal.attachmentModalContent.querySelector('pre');
             expect(pre).toBeTruthy();
             expect(pre.textContent).toBe('Hello');
         });
+
+        test('decodes text previews using data URL charset', () => {
+            const base64 = Buffer.from('Freundliche Gr\xFC\xDFe', 'binary').toString('base64');
+            const att = {
+                fileName: 'test.txt',
+                attachMimeTag: 'text/plain',
+                contentBase64: `data:text/plain;charset=windows-1252;base64,${base64}`
+            };
+            modal.setAttachments([att]);
+            modal.renderAttachmentPreview(att);
+            const pre = modal.attachmentModalContent.querySelector('pre');
+            expect(pre.textContent).toBe('Freundliche Grüße');
+        });
     });
 
     describe('navigation', () => {
         const attachments = [
-            { fileName: '1.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,1' },
-            { fileName: '2.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,2' },
-            { fileName: '3.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,3' }
+            {
+                fileName: '1.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,1'
+            },
+            {
+                fileName: '2.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,2'
+            },
+            {
+                fileName: '3.png',
+                attachMimeTag: 'image/png',
+                contentBase64: 'data:image/png;base64,3'
+            }
         ];
 
         test('showNextAttachment advances', () => {
@@ -730,8 +834,16 @@ describe('AttachmentModalManager', () => {
 
         test('prev button navigates', () => {
             const attachments = [
-                { fileName: '1.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,1' },
-                { fileName: '2.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,2' }
+                {
+                    fileName: '1.png',
+                    attachMimeTag: 'image/png',
+                    contentBase64: 'data:image/png;base64,1'
+                },
+                {
+                    fileName: '2.png',
+                    attachMimeTag: 'image/png',
+                    contentBase64: 'data:image/png;base64,2'
+                }
             ];
             modal.setAttachments(attachments);
             modal.open(attachments[1]);
@@ -741,8 +853,16 @@ describe('AttachmentModalManager', () => {
 
         test('next button navigates', () => {
             const attachments = [
-                { fileName: '1.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,1' },
-                { fileName: '2.png', attachMimeTag: 'image/png', contentBase64: 'data:image/png;base64,2' }
+                {
+                    fileName: '1.png',
+                    attachMimeTag: 'image/png',
+                    contentBase64: 'data:image/png;base64,1'
+                },
+                {
+                    fileName: '2.png',
+                    attachMimeTag: 'image/png',
+                    contentBase64: 'data:image/png;base64,2'
+                }
             ];
             modal.setAttachments(attachments);
             modal.open(attachments[0]);
@@ -754,9 +874,16 @@ describe('AttachmentModalManager', () => {
     describe('Tauri PDF handling', () => {
         test('opens PDF with system viewer in Tauri', () => {
             isTauri.mockReturnValue(true);
-            const pdfAtt = { fileName: 'test.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:application/pdf;base64,abc' };
+            const pdfAtt = {
+                fileName: 'test.pdf',
+                attachMimeTag: 'application/pdf',
+                contentBase64: 'data:application/pdf;base64,abc'
+            };
             modal.open(pdfAtt);
-            expect(openWithSystemViewer).toHaveBeenCalledWith('data:application/pdf;base64,abc', 'test.pdf');
+            expect(openWithSystemViewer).toHaveBeenCalledWith(
+                'data:application/pdf;base64,abc',
+                'test.pdf'
+            );
             expect(modal.attachmentModal.classList.contains('active')).toBe(false);
         });
     });
@@ -817,19 +944,30 @@ describe('MessageListRenderer', () => {
     });
 
     test('shows attachment icon for messages with attachments', () => {
-        mockHandler.getMessages.mockReturnValue([createMockMessage({ attachments: [{ fileName: 'att.pdf' }] })]);
+        mockHandler.getMessages.mockReturnValue([
+            createMockMessage({ attachments: [{ fileName: 'att.pdf' }] })
+        ]);
         renderer.render();
         expect(container.querySelector('.attachment-icon')).toBeTruthy();
     });
 
     test('does not show attachment icon for inline attachments only', () => {
-        mockHandler.getMessages.mockReturnValue([createMockMessage({ attachments: [{ fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid123' }] })]);
+        mockHandler.getMessages.mockReturnValue([
+            createMockMessage({
+                attachments: [
+                    { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid123' }
+                ]
+            })
+        ]);
         renderer.render();
         expect(container.querySelector('.attachment-icon')).toBeFalsy();
     });
 
     test('sets data-message-index attribute', () => {
-        mockHandler.getMessages.mockReturnValue([createMockMessage(), createMockMessage({ subject: 'Second' })]);
+        mockHandler.getMessages.mockReturnValue([
+            createMockMessage(),
+            createMockMessage({ subject: 'Second' })
+        ]);
         renderer.render();
         const items = container.querySelectorAll('[data-message-index]');
         expect(items[0].dataset.messageIndex).toBe('0');
@@ -932,16 +1070,27 @@ describe('MessageContentRenderer', () => {
     });
 
     test('renders HTML body content', () => {
-        renderer.render(createMockMessage({ bodyContentHTML: '<p>This is <strong>HTML</strong></p>' }));
+        renderer.render(
+            createMockMessage({ bodyContentHTML: '<p>This is <strong>HTML</strong></p>' })
+        );
         expect(container.innerHTML).toContain('<strong>HTML</strong>');
     });
 
     test('marks inline images as previewable controls', () => {
         const inlineImage = 'data:image/png;base64,abc';
-        renderer.render(createMockMessage({
-            bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image"></p>`,
-            attachments: [{ fileName: 'inline-image.png', attachMimeTag: 'image/png', contentBase64: inlineImage, pidContentId: 'cid-1' }]
-        }));
+        renderer.render(
+            createMockMessage({
+                bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image"></p>`,
+                attachments: [
+                    {
+                        fileName: 'inline-image.png',
+                        attachMimeTag: 'image/png',
+                        contentBase64: inlineImage,
+                        pidContentId: 'cid-1'
+                    }
+                ]
+            })
+        );
 
         const image = container.querySelector('.email-content img');
         expect(image.dataset.inlineImagePreviewable).toBe('true');
@@ -952,10 +1101,19 @@ describe('MessageContentRenderer', () => {
 
     test('clicking inline images opens the modal preview', () => {
         const inlineImage = 'data:image/png;base64,abc';
-        renderer.render(createMockMessage({
-            bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image"></p>`,
-            attachments: [{ fileName: 'inline-image.png', attachMimeTag: 'image/png', contentBase64: inlineImage, pidContentId: 'cid-1' }]
-        }));
+        renderer.render(
+            createMockMessage({
+                bodyContentHTML: `<p><img src="${inlineImage}" alt="inline-image"></p>`,
+                attachments: [
+                    {
+                        fileName: 'inline-image.png',
+                        attachMimeTag: 'image/png',
+                        contentBase64: inlineImage,
+                        pidContentId: 'cid-1'
+                    }
+                ]
+            })
+        );
 
         container.querySelector('.email-content img').click();
 
@@ -968,10 +1126,19 @@ describe('MessageContentRenderer', () => {
 
     test('captures source links for linked inline images', () => {
         const inlineImage = 'data:image/png;base64,abc';
-        renderer.render(createMockMessage({
-            bodyContentHTML: `<p><a href="https://example.com/details"><img src="${inlineImage}" alt="inline-image"></a></p>`,
-            attachments: [{ fileName: 'inline-image.png', attachMimeTag: 'image/png', contentBase64: inlineImage, pidContentId: 'cid-1' }]
-        }));
+        renderer.render(
+            createMockMessage({
+                bodyContentHTML: `<p><a href="https://example.com/details"><img src="${inlineImage}" alt="inline-image"></a></p>`,
+                attachments: [
+                    {
+                        fileName: 'inline-image.png',
+                        attachMimeTag: 'image/png',
+                        contentBase64: inlineImage,
+                        pidContentId: 'cid-1'
+                    }
+                ]
+            })
+        );
 
         const image = container.querySelector('.email-content img');
         image.click();
@@ -990,18 +1157,30 @@ describe('MessageContentRenderer', () => {
         const iconImage = 'data:image/png;base64,icon';
         const screenshotImage = 'data:image/png;base64,screen';
 
-        renderer.render(createMockMessage({
-            bodyContentHTML: `
+        renderer.render(
+            createMockMessage({
+                bodyContentHTML: `
                 <p>
                     <img src="${iconImage}" alt="asset-a.png" width="84" height="67">
                     <img src="${screenshotImage}" alt="asset-b.jpg" width="640" height="480">
                 </p>
             `,
-            attachments: [
-                { fileName: 'asset-a.png', attachMimeTag: 'image/png', contentBase64: iconImage, pidContentId: 'cid-a' },
-                { fileName: 'asset-b.jpg', attachMimeTag: 'image/png', contentBase64: screenshotImage, pidContentId: 'cid-b' }
-            ]
-        }));
+                attachments: [
+                    {
+                        fileName: 'asset-a.png',
+                        attachMimeTag: 'image/png',
+                        contentBase64: iconImage,
+                        pidContentId: 'cid-a'
+                    },
+                    {
+                        fileName: 'asset-b.jpg',
+                        attachMimeTag: 'image/png',
+                        contentBase64: screenshotImage,
+                        pidContentId: 'cid-b'
+                    }
+                ]
+            })
+        );
 
         const images = container.querySelectorAll('.email-content img');
         expect(images[0].hidden).toBe(false);
@@ -1032,7 +1211,9 @@ describe('MessageContentRenderer', () => {
         mockHandler.getMessages.mockReturnValue([msg]);
         mockHandler.isPinned.mockReturnValue(true);
         renderer.render(msg);
-        expect(container.querySelector('[data-action="pin"]').classList.contains('pinned')).toBe(true);
+        expect(container.querySelector('[data-action="pin"]').classList.contains('pinned')).toBe(
+            true
+        );
     });
 
     describe('formatRecipients', () => {
@@ -1115,8 +1296,17 @@ describe('MessageContentRenderer', () => {
 
         test('keeps inline images out of the modal sequence while the section is collapsed', () => {
             const attachments = [
-                { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
-                { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:inline' }
+                {
+                    fileName: 'doc.pdf',
+                    attachMimeTag: 'application/pdf',
+                    contentBase64: 'data:pdf'
+                },
+                {
+                    fileName: 'inline.png',
+                    attachMimeTag: 'image/png',
+                    pidContentId: 'cid-1',
+                    contentBase64: 'data:inline'
+                }
             ];
 
             renderer.renderAttachments({ attachments });
@@ -1125,16 +1315,29 @@ describe('MessageContentRenderer', () => {
         });
 
         test('renders attachment count', () => {
-            expect(renderer.renderAttachments({ attachments: [{ fileName: 'a.pdf' }] })).toContain('1 Attachment');
+            expect(renderer.renderAttachments({ attachments: [{ fileName: 'a.pdf' }] })).toContain(
+                '1 Attachment'
+            );
         });
 
         test('renders plural for multiple', () => {
-            expect(renderer.renderAttachments({ attachments: [{ fileName: 'a.pdf' }, { fileName: 'b.pdf' }] })).toContain('2 Attachments');
+            expect(
+                renderer.renderAttachments({
+                    attachments: [{ fileName: 'a.pdf' }, { fileName: 'b.pdf' }]
+                })
+            ).toContain('2 Attachments');
         });
 
         test('renders inline images in a separate collapsed section', () => {
             const result = renderer.renderAttachments({
-                attachments: [{ fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }]
+                attachments: [
+                    {
+                        fileName: 'inline.png',
+                        attachMimeTag: 'image/png',
+                        pidContentId: 'cid-1',
+                        contentBase64: 'data:'
+                    }
+                ]
             });
             expect(result).toContain('Inline image');
             expect(result).toContain('data-inline-images-toggle');
@@ -1143,24 +1346,53 @@ describe('MessageContentRenderer', () => {
 
         test('renders previewable with preview action', () => {
             mockModal.isPreviewable.mockReturnValue(true);
-            const result = renderer.renderAttachments({ attachments: [{ fileName: 'img.png', attachMimeTag: 'image/png', contentBase64: 'data:', contentLength: 100 }] });
+            const result = renderer.renderAttachments({
+                attachments: [
+                    {
+                        fileName: 'img.png',
+                        attachMimeTag: 'image/png',
+                        contentBase64: 'data:',
+                        contentLength: 100
+                    }
+                ]
+            });
             expect(result).toContain('data-action="preview"');
         });
 
         test('renders non-previewable as download', () => {
             mockModal.isPreviewable.mockReturnValue(false);
-            const result = renderer.renderAttachments({ attachments: [{ fileName: 'archive.zip', attachMimeTag: 'application/zip', contentBase64: 'data:', contentLength: 100 }] });
+            const result = renderer.renderAttachments({
+                attachments: [
+                    {
+                        fileName: 'archive.zip',
+                        attachMimeTag: 'application/zip',
+                        contentBase64: 'data:',
+                        contentLength: 100
+                    }
+                ]
+            });
             expect(result).toContain('data-action="download"');
             expect(result).not.toContain('data-action="preview"');
         });
 
         test('persists inline image section visibility when toggled', () => {
-            renderer.render(createMockMessage({
-                attachments: [
-                    { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
-                    { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }
-                ]
-            }));
+            renderer.render(
+                createMockMessage({
+                    attachments: [
+                        {
+                            fileName: 'doc.pdf',
+                            attachMimeTag: 'application/pdf',
+                            contentBase64: 'data:pdf'
+                        },
+                        {
+                            fileName: 'inline.png',
+                            attachMimeTag: 'image/png',
+                            pidContentId: 'cid-1',
+                            contentBase64: 'data:'
+                        }
+                    ]
+                })
+            );
 
             const toggle = container.querySelector('[data-inline-images-toggle]');
             const content = container.querySelector('[data-inline-images-content]');
@@ -1172,10 +1404,21 @@ describe('MessageContentRenderer', () => {
 
             expect(toggle.getAttribute('aria-expanded')).toBe('true');
             expect(content.hidden).toBe(false);
-            expect(JSON.parse(window.localStorage.getItem('msgReader_inlineImageAttachments'))).toBe('expanded');
+            expect(
+                JSON.parse(window.localStorage.getItem('msgReader_inlineImageAttachments'))
+            ).toBe('expanded');
             expect(mockModal.setAttachments).toHaveBeenLastCalledWith([
-                { fileName: 'doc.pdf', attachMimeTag: 'application/pdf', contentBase64: 'data:pdf' },
-                { fileName: 'inline.png', attachMimeTag: 'image/png', pidContentId: 'cid-1', contentBase64: 'data:' }
+                {
+                    fileName: 'doc.pdf',
+                    attachMimeTag: 'application/pdf',
+                    contentBase64: 'data:pdf'
+                },
+                {
+                    fileName: 'inline.png',
+                    attachMimeTag: 'image/png',
+                    pidContentId: 'cid-1',
+                    contentBase64: 'data:'
+                }
             ]);
         });
     });
@@ -1185,16 +1428,26 @@ describe('Edge cases', () => {
     test('AttachmentModalManager handles missing modal element', () => {
         document.body.innerHTML = '';
         const modal = new AttachmentModalManager(jest.fn());
-        expect(() => modal.open({ fileName: 'test.png', attachMimeTag: 'image/png' })).not.toThrow();
+        expect(() =>
+            modal.open({ fileName: 'test.png', attachMimeTag: 'image/png' })
+        ).not.toThrow();
     });
 
     test('MessageListRenderer handles null container', () => {
-        const renderer = new MessageListRenderer(null, { getMessages: () => [], getCurrentMessage: () => null, isPinned: () => false });
+        const renderer = new MessageListRenderer(null, {
+            getMessages: () => [],
+            getCurrentMessage: () => null,
+            isPinned: () => false
+        });
         expect(() => renderer.render()).not.toThrow();
     });
 
     test('MessageContentRenderer handles null container', () => {
-        const renderer = new MessageContentRenderer(null, { setCurrentMessage: jest.fn(), getMessages: () => [], isPinned: () => false }, null);
+        const renderer = new MessageContentRenderer(
+            null,
+            { setCurrentMessage: jest.fn(), getMessages: () => [], isPinned: () => false },
+            null
+        );
         expect(() => renderer.render(createMockMessage())).not.toThrow();
     });
 });

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -20,6 +20,8 @@ describe('CHARSET_CODES', () => {
         expect(CHARSET_CODES[932]).toBe('shift_jis');
         expect(CHARSET_CODES[949]).toBe('cp949');
         expect(CHARSET_CODES[928]).toBe('gb2312');
+        expect(CHARSET_CODES[1252]).toBe('windows-1252');
+        expect(CHARSET_CODES[65001]).toBe('utf-8');
     });
 
     test('is not empty', () => {

--- a/tests/encoding.test.js
+++ b/tests/encoding.test.js
@@ -1,0 +1,42 @@
+import {
+    decodeBase64Text,
+    decodeBinaryString,
+    decodeMimeWords,
+    decodePercentEncodedText,
+    textToBase64
+} from '../src/js/encoding.js';
+
+describe('encoding helpers', () => {
+    test('decodes Windows-1252 binary strings', () => {
+        expect(decodeBinaryString('Freundliche Gr\xFC\xDFe', 'windows-1252')).toBe(
+            'Freundliche Grüße'
+        );
+    });
+
+    test('falls back from invalid UTF-8 to Windows-1252', () => {
+        expect(decodeBinaryString('Somit ist der Gremienvorbehalt ausger\xE4umt.', 'utf-8')).toBe(
+            'Somit ist der Gremienvorbehalt ausgeräumt.'
+        );
+    });
+
+    test('uses Windows-1252 fallback for unsupported charsets with invalid UTF-8 bytes', () => {
+        expect(decodeBinaryString('Freundliche Gr\xFC\xDFe', 'x-unknown-charset')).toBe(
+            'Freundliche Grüße'
+        );
+    });
+
+    test('keeps valid UTF-8 content as UTF-8', () => {
+        const base64 = textToBase64('Freundliche Grüße');
+        expect(decodeBase64Text(base64, 'utf-8')).toBe('Freundliche Grüße');
+    });
+
+    test('decodes adjacent MIME encoded words', () => {
+        expect(decodeMimeWords('=?UTF-8?Q?Freundliche?= =?UTF-8?Q?_Gr=C3=BC=C3=9Fe?=')).toBe(
+            'Freundliche Grüße'
+        );
+    });
+
+    test('decodes RFC 2231 percent-encoded bytes with charset', () => {
+        expect(decodePercentEncodedText('Gr%FC%DFe.txt', 'iso-8859-1')).toBe('Grüße.txt');
+    });
+});

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -66,10 +66,12 @@ describe('getCharsetFromCodepage', () => {
         expect(getCharsetFromCodepage(932)).toBe('shift_jis');
         expect(getCharsetFromCodepage(949)).toBe('cp949');
         expect(getCharsetFromCodepage(928)).toBe('gb2312');
+        expect(getCharsetFromCodepage(1252)).toBe('windows-1252');
+        expect(getCharsetFromCodepage(65001)).toBe('utf-8');
+        expect(getCharsetFromCodepage(28591)).toBe('iso-8859-1');
     });
 
     test('returns utf-8 for unknown code pages', () => {
-        expect(getCharsetFromCodepage(1252)).toBe('utf-8');
         expect(getCharsetFromCodepage(0)).toBe('utf-8');
         expect(getCharsetFromCodepage(undefined)).toBe('utf-8');
         expect(getCharsetFromCodepage(null)).toBe('utf-8');
@@ -115,27 +117,35 @@ describe('isImageMimeType', () => {
 
 describe('isInlineImageAttachment', () => {
     test('returns true for image attachments with content ids', () => {
-        expect(isInlineImageAttachment({
-            attachMimeTag: 'image/png',
-            pidContentId: 'cid-1'
-        })).toBe(true);
+        expect(
+            isInlineImageAttachment({
+                attachMimeTag: 'image/png',
+                pidContentId: 'cid-1'
+            })
+        ).toBe(true);
 
-        expect(isInlineImageAttachment({
-            attachMimeTag: 'image/jpeg',
-            contentId: 'cid-2'
-        })).toBe(true);
+        expect(
+            isInlineImageAttachment({
+                attachMimeTag: 'image/jpeg',
+                contentId: 'cid-2'
+            })
+        ).toBe(true);
     });
 
     test('returns false for regular attachments', () => {
-        expect(isInlineImageAttachment({
-            attachMimeTag: 'image/png',
-            fileName: 'photo.png'
-        })).toBe(false);
+        expect(
+            isInlineImageAttachment({
+                attachMimeTag: 'image/png',
+                fileName: 'photo.png'
+            })
+        ).toBe(false);
 
-        expect(isInlineImageAttachment({
-            attachMimeTag: 'application/pdf',
-            pidContentId: 'cid-3'
-        })).toBe(false);
+        expect(
+            isInlineImageAttachment({
+                attachMimeTag: 'application/pdf',
+                pidContentId: 'cid-3'
+            })
+        ).toBe(false);
     });
 });
 
@@ -163,7 +173,9 @@ describe('extractBaseMimeType', () => {
     test('extracts base MIME type', () => {
         expect(extractBaseMimeType('text/html; charset=utf-8')).toBe('text/html');
         expect(extractBaseMimeType('application/json')).toBe('application/json');
-        expect(extractBaseMimeType('multipart/mixed; boundary="----=_Part"')).toBe('multipart/mixed');
+        expect(extractBaseMimeType('multipart/mixed; boundary="----=_Part"')).toBe(
+            'multipart/mixed'
+        );
     });
 
     test('handles empty or null input', () => {
@@ -187,8 +199,12 @@ describe('extractCharset', () => {
 
 describe('extractBoundary', () => {
     test('extracts boundary from multipart content-type', () => {
-        expect(extractBoundary('multipart/mixed; boundary="----=_Part_123"')).toBe('----=_Part_123');
-        expect(extractBoundary('multipart/alternative; boundary=simple_boundary')).toBe('simple_boundary');
+        expect(extractBoundary('multipart/mixed; boundary="----=_Part_123"')).toBe(
+            '----=_Part_123'
+        );
+        expect(extractBoundary('multipart/alternative; boundary=simple_boundary')).toBe(
+            'simple_boundary'
+        );
     });
 
     test('returns null for non-multipart', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,7 +5,11 @@
 jest.mock('@kenjiuno/msgreader', () => jest.fn());
 
 import MsgReaderLib from '@kenjiuno/msgreader';
-import { extractMsg } from '../src/js/utils.js';
+import { extractEml, extractMsg } from '../src/js/utils.js';
+
+function binaryArrayBuffer(value) {
+    return Uint8Array.from(Buffer.from(value, 'binary')).buffer;
+}
 
 describe('extractMsg', () => {
     const mockGetFileData = jest.fn();
@@ -28,12 +32,14 @@ describe('extractMsg', () => {
             senderEmail: 'alice@example.com',
             messageDeliveryTime: '2026-01-01T10:00:00Z',
             body: 'Hello',
-            attachments: [{
-                dataId: 1,
-                attachMimeTag: 'application/pdf',
-                name: 'Quarterly Results',
-                extension: '.pdf'
-            }]
+            attachments: [
+                {
+                    dataId: 1,
+                    attachMimeTag: 'application/pdf',
+                    name: 'Quarterly Results',
+                    extension: '.pdf'
+                }
+            ]
         });
 
         mockGetAttachment.mockReturnValue({
@@ -54,11 +60,13 @@ describe('extractMsg', () => {
             senderEmail: 'alice@example.com',
             messageDeliveryTime: '2026-01-01T10:00:00Z',
             body: 'Hello',
-            attachments: [{
-                dataId: 2,
-                attachMimeTag: 'application/pdf',
-                fileNameShort: 'REPORT~1.PDF'
-            }]
+            attachments: [
+                {
+                    dataId: 2,
+                    attachMimeTag: 'application/pdf',
+                    fileNameShort: 'REPORT~1.PDF'
+                }
+            ]
         });
 
         mockGetAttachment.mockReturnValue({
@@ -78,10 +86,12 @@ describe('extractMsg', () => {
             senderEmail: 'alice@example.com',
             messageDeliveryTime: '2026-01-01T10:00:00Z',
             body: 'Hello',
-            attachments: [{
-                dataId: 3,
-                attachMimeTag: 'application/pdf'
-            }]
+            attachments: [
+                {
+                    dataId: 3,
+                    attachMimeTag: 'application/pdf'
+                }
+            ]
         });
 
         mockGetAttachment.mockReturnValue({
@@ -92,5 +102,103 @@ describe('extractMsg', () => {
         const result = extractMsg(new ArrayBuffer(0));
 
         expect(result.attachments[0].fileName).toBe('attachment.pdf');
+    });
+
+    test('decodes MSG HTML using Windows-1252 internet codepage', () => {
+        mockGetFileData.mockReturnValue({
+            subject: 'German text',
+            senderName: 'Alice',
+            senderEmail: 'alice@example.com',
+            messageDeliveryTime: '2026-01-01T10:00:00Z',
+            body: '',
+            internetCodepage: 1252,
+            html: Uint8Array.from(
+                Buffer.from(
+                    '<p>Somit ist der Gremienvorbehalt ausger\xE4umt.</p><p>Freundliche Gr\xFC\xDFe</p>',
+                    'binary'
+                )
+            ),
+            attachments: []
+        });
+
+        const result = extractMsg(new ArrayBuffer(0));
+
+        expect(result.bodyContentHTML).toContain('ausgeräumt');
+        expect(result.bodyContentHTML).toContain('Freundliche Grüße');
+        expect(result.bodyContentHTML).not.toContain('\uFFFD');
+    });
+});
+
+describe('extractEml', () => {
+    test('decodes 8bit body content using declared Windows-1252 charset', () => {
+        const eml = [
+            'From: Brigitte Korn-Hoffmann <brigitte@example.com>',
+            'Subject: =?windows-1252?Q?Freundliche_Gr=FC=DFe?=',
+            'Content-Type: text/plain; charset=windows-1252',
+            'Content-Transfer-Encoding: 8bit',
+            '',
+            'Freundliche Gr\xFC\xDFe'
+        ].join('\r\n');
+
+        const result = extractEml(binaryArrayBuffer(eml));
+
+        expect(result.subject).toBe('Freundliche Grüße');
+        expect(result.bodyContent).toBe('Freundliche Grüße');
+    });
+
+    test('falls back to Windows-1252 when unlabelled 8bit text is invalid UTF-8', () => {
+        const eml = [
+            'From: test@example.com',
+            'Subject: Charset fallback',
+            'Content-Type: text/plain',
+            'Content-Transfer-Encoding: 8bit',
+            '',
+            'Somit ist der Gremienvorbehalt ausger\xE4umt.'
+        ].join('\r\n');
+
+        const result = extractEml(binaryArrayBuffer(eml));
+
+        expect(result.bodyContent).toBe('Somit ist der Gremienvorbehalt ausgeräumt.');
+    });
+
+    test('decodes quoted-printable HTML using ISO-8859-1 charset', () => {
+        const eml = [
+            'From: test@example.com',
+            'Subject: Quoted printable',
+            'Content-Type: text/html; charset=iso-8859-1',
+            'Content-Transfer-Encoding: quoted-printable',
+            '',
+            '<p>Freundliche Gr=FC=DFe</p>'
+        ].join('\r\n');
+
+        const result = extractEml(binaryArrayBuffer(eml));
+
+        expect(result.bodyContentHTML).toBe('<p>Freundliche Grüße</p>');
+    });
+
+    test('decodes RFC 2231 attachment filenames', () => {
+        const eml = [
+            'From: test@example.com',
+            'Subject: Attachment filename',
+            'Content-Type: multipart/mixed; boundary="b1"',
+            '',
+            '--b1',
+            'Content-Type: text/plain; charset=utf-8',
+            '',
+            'Body',
+            '--b1',
+            "Content-Type: text/plain; name*=iso-8859-1''Gr%FC%DFe.txt",
+            "Content-Disposition: attachment; filename*=iso-8859-1''Gr%FC%DFe.txt",
+            'Content-Transfer-Encoding: quoted-printable',
+            '',
+            'Hallo',
+            '--b1--',
+            ''
+        ].join('\r\n');
+
+        const result = extractEml(binaryArrayBuffer(eml));
+
+        expect(result.attachments[0].fileName).toBe('Grüße.txt');
+        expect(result.attachments[0].contentBase64).toBe('data:text/plain;base64,SGFsbG8=');
     });
 });


### PR DESCRIPTION
## Summary
- add centralized charset/base64/quoted-printable decoding helpers
- decode MSG/EML text, MIME headers, RFC2231 filenames, text attachments, and nested EMLs through byte-safe paths
- add regression coverage for German Windows-1252 text, UTF-8 fallback behavior, quoted-printable HTML, and attachment filenames

## Verification
- npm test
- npm run lint
- npm run build

Note: repo-wide `npm run format:check` still reports pre-existing unformatted files outside this change; touched files pass Prettier after fixing the invalid `.prettierrc` option.